### PR TITLE
Add CR2 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,11 +32,12 @@ module.exports = function (buf) {
 		};
 	}
 
+	// needs to be before `tif` check
 	if (((buf[0] === 0x49 && buf[1] === 0x49 && buf[2] === 0x2A && buf[3] === 0x0) || (buf[0] === 0x4D && buf[1] === 0x4D && buf[2] === 0x0 && buf[3] === 0x2A)) && buf[8] === 0x43 && buf[9] === 0x52) {
 		return {
-			ext: 'CR2',
+			ext: 'cr2',
 			mime: 'image/x-canon-cr2'
-		}
+		};
 	}
 
 	if ((buf[0] === 0x49 && buf[1] === 0x49 && buf[2] === 0x2A && buf[3] === 0x0) || (buf[0] === 0x4D && buf[1] === 0x4D && buf[2] === 0x0 && buf[3] === 0x2A)) {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,13 @@ module.exports = function (buf) {
 		};
 	}
 
+	if (((buf[0] === 0x49 && buf[1] === 0x49 && buf[2] === 0x2A && buf[3] === 0x0) || (buf[0] === 0x4D && buf[1] === 0x4D && buf[2] === 0x0 && buf[3] === 0x2A)) && buf[8] === 0x43 && buf[9] === 0x52) {
+		return {
+			ext: 'CR2',
+			mime: 'image/x-canon-cr2'
+		}
+	}
+
 	if ((buf[0] === 0x49 && buf[1] === 0x49 && buf[2] === 0x2A && buf[3] === 0x0) || (buf[0] === 0x4D && buf[1] === 0x4D && buf[2] === 0x0 && buf[3] === 0x2A)) {
 		return {
 			ext: 'tif',

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "png",
     "gif",
     "webp",
+    "CR2",
     "tif",
     "bmp",
     "jxr",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "png",
     "gif",
     "webp",
-    "CR2",
+    "cr2",
     "tif",
     "bmp",
     "jxr",

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ $ file-type --help
 - `png`
 - `gif`
 - `webp`
+- `cr2`
 - `tif`
 - `bmp`
 - `jxr`

--- a/test.js
+++ b/test.js
@@ -14,7 +14,7 @@ var types = [
 	'png',
 	'gif',
 	'webp',
-	'CR2',
+	'cr2',
 	'tif',
 	'bmp',
 	'jxr',

--- a/test.js
+++ b/test.js
@@ -14,6 +14,7 @@ var types = [
 	'png',
 	'gif',
 	'webp',
+	'CR2',
 	'tif',
 	'bmp',
 	'jxr',


### PR DESCRIPTION
Added support for CR2. The first bytes are the same as TIFF, so it had to be placed before.

The extension is capitalized (`.CR2`) importing the photos from my camera, so I kept it that way. Should it be in lowercase?