### PR TITLE
Fix eot mime type

### DIFF
--- a/index.js
+++ b/index.js
@@ -556,7 +556,7 @@ module.exports = input => {
 	) {
 		return {
 			ext: 'eot',
-			mime: 'application/octet-stream'
+			mime: 'application/vnd.ms-fontobject'
 		};
 	}
 


### PR DESCRIPTION
The `application/octet-stream` is not the correct mime of an `eot`. It's supposed to be `application/vnd.ms-fontobject`. See [Wikipedia](https://en.wikipedia.org/wiki/Embedded_OpenType) or [Nginx implementation](https://github.com/nginx/nginx/blob/3b1589173f28fccb5816669f3ff4c9ac1e9b573c/conf/mime.types#L41) for example.