### PR TITLE
Improve usage example in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ const fileType = require('file-type');
 const url = 'http://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif';
 
 http.get(url, res => {
-	res.on('readable', () => {
+	res.on('readable', function () {
 		let chunk = this.read(fileType.minimumBytes);
 		res.destroy();
 		console.log(fileType(chunk));

--- a/readme.md
+++ b/readme.md
@@ -38,10 +38,10 @@ const fileType = require('file-type');
 
 const url = 'http://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif';
 
-http.get(url, res => {
-	res.on('readable', function () {
-		let chunk = this.read(fileType.minimumBytes);
-		res.destroy();
+http.get(url, response => {
+	response.on('readable', () => {
+		const chunk = response.read(fileType.minimumBytes);
+		response.destroy();
 		console.log(fileType(chunk));
 		//=> {ext: 'gif', mime: 'image/gif'}
 	});

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,8 @@ const fileType = require('file-type');
 const url = 'http://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif';
 
 http.get(url, res => {
-	res.once('data', chunk => {
+	res.on('readable', () => {
+		let chunk = this.read(fileType.minimumBytes);
 		res.destroy();
 		console.log(fileType(chunk));
 		//=> {ext: 'gif', mime: 'image/gif'}


### PR DESCRIPTION
The stream MUST NOT supply enough data to determine what filetype is it. New API allows it.