### PR TITLE
Support for all kinds of streams in readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,10 +40,12 @@ const url = 'http://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif
 
 http.get(url, response => {
 	response.on('readable', () => {
-		const chunk = response.read(fileType.minimumBytes);
-		response.destroy();
-		console.log(fileType(chunk));
-		//=> {ext: 'gif', mime: 'image/gif'}
+		let chunk;
+		while (null !== (chunk = response.read(fileType.minimumBytes))) {
+			console.log(fileType(chunk));
+			// => {ext: 'gif', mime: 'image/gif'}
+			response.destroy();
+		}
 	});
 });
 ```


### PR DESCRIPTION
After some feedback and testing I found out, that previous solution works only on sync streams. The `read` function can return null if the buffer is not ready yet. If you want more general solution, this one will work with sync and async streams. Approved by official docs: https://nodejs.org/api/stream.html#stream_readable_read_size