### PR TITLE
Add support for GLB

### DIFF
--- a/index.js
+++ b/index.js
@@ -901,6 +901,13 @@ module.exports = input => {
 		};
 	}
 
+	if (check([0x67, 0x6C, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00])) {
+		return {
+			ext: 'glb',
+			mime: 'application/octet-stream'
+		};
+	}
+
 	return null;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "file-type",
-	"version": "10.6.0",
+	"version": "10.6.1",
 	"description": "Detect the file type of a Buffer/Uint8Array",
 	"license": "MIT",
 	"repository": "sindresorhus/file-type",
@@ -115,7 +115,8 @@
 		"xml",
 		"heic",
 		"wma",
-		"ics"
+		"ics",
+	    "glb"
 	],
 	"devDependencies": {
 		"ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,7 @@ The minimum amount of bytes needed to detect a file type. Currently, it's 4100 b
 - [`dcm`](https://en.wikipedia.org/wiki/DICOM#Data_format) - DICOM Image File
 - [`mpc`](https://en.wikipedia.org/wiki/Musepack) - Musepack (SV7 & SV8)
 - [`ics`](https://en.wikipedia.org/wiki/ICalendar#Data_format) - iCalendar
+- [`glb`](https://github.com/KhronosGroup/glTF) - GL Transmission Format
 
 *SVG isn't included as it requires the whole file to be read, but you can get it [here](https://github.com/sindresorhus/is-svg).*
 

--- a/test.js
+++ b/test.js
@@ -99,7 +99,8 @@ const types = [
 	'wmv',
 	'wma',
 	'dcm',
-	'ics'
+	'ics',
+	'glb'
 ];
 
 // Define an entry here only if the fixture has a different


### PR DESCRIPTION
GLB files are compressed GLTF files.
Website:
https://github.com/KhronosGroup/glTF
Detection information (magic number, header, content, body, etc):
https://github.com/KhronosGroup/glTF/tree/master/extensions/1.0/Khronos/KHR_binary_glTF

![](https://raw.githubusercontent.com/KhronosGroup/glTF/master/extensions/1.0/Khronos/KHR_binary_glTF/figures/layout.png)

If you're adding support for a new file type, please follow the below steps:

[x] Add a fixture file named `fixture.<extension>` to the `fixture` directory.
[x] Add the file extension to the `types` array in `test.js`.
[x] Add the file type detection logic to the `index.js` file.
[x] Add the file extension to the `Supported file types` section in the readme, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```
[x] Add the file extension to the `keywords` array in the `package.json` file.
[x] Run `$ npm test` to ensure the tests pass.
[x] Open a pull request with a little like `Add support for Format`, for example, `Add support for PNG`.
[x] The pull request description should include a link to the official page of the file format or some other source. Also include a link to where you found the file type detection / magic bytes.
