### PR TITLE
Improve parsing 3gp video subtypes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,7 +308,17 @@ module.exports = input => {
 		};
 	}
 
-	if (check([0x0, 0x0, 0x0, 0x1C, 0x66, 0x74, 0x79, 0x70, 0x33, 0x67, 0x70, 0x34])) {
+	// if (check([0x0, 0x0, 0x0, 0x1C, 0x66, 0x74, 0x79, 0x70, 0x33, 0x67, 0x70, 0x34])) {
+	// 	return {
+	// 		ext: '3gp',
+	// 		mime: 'video/3gpp'
+	// 	};
+	// }
+
+	// all 3gp subtypes files support
+	// 3GG, 3GP, 3G2, 3gp5 	3rd Generation Partnership Project 3GPP, 3GPP2 multimedia files
+	// TODO: need to separate 3gp, 3gp2 and 3gp5 files checking. The 'mime' should be different for these types
+	if (check([0x66, 0x74, 0x79, 0x70, 0x33, 0x67, 0x70], {offset: 4})) {
 		return {
 			ext: '3gp',
 			mime: 'video/3gpp'


### PR DESCRIPTION
If you're adding support for a new file type, please follow the below steps:

- Add a fixture file named `fixture.<extension>` to the `fixture` directory.
- Add the file extension to the `types` array in `test.js`.
- Add the file type detection logic to the `index.js` file.
- Add the file extension to the `Supported file types` section in the readme, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```
- Add the file extension to the `keywords` array in the `package.json` file.
- Run `$ npm test` to ensure the tests pass.
- Open a pull request with a little like `Add support for Format`, for example, `Add support for PNG`.
- The pull request description should include a link to the official page of the file format or some other source. Also include a link to where you found the file type detection / magic bytes.
