### PR TITLE
Remove incorrect byte from `aiff` check

### DIFF
--- a/index.js
+++ b/index.js
@@ -812,7 +812,7 @@ module.exports = input => {
 		}
 	}
 
-	if (check([0x46, 0x4F, 0x52, 0x4D, 0x00])) {
+	if (check([0x46, 0x4F, 0x52, 0x4D])) {
 		return {
 			ext: 'aif',
 			mime: 'audio/aiff'


### PR DESCRIPTION
The first four bytes should be the string `FORM`. See http://www.onicos.com/staff/iz/formats/aiff.html for reference.

I didn't include the fixture linked in the issue because of its size, but I tested with it and it passed the tests.

Fixes #182.
