### PR TITLE
Add `.stream()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -919,16 +919,15 @@ module.exports = input => {
 
 Object.defineProperty(module.exports, 'minimumBytes', {value: 4100});
 
-module.exports.stream = readableStream => new Promise((resolve, reject) => {
+module.exports.stream = readableStream => new Promise(resolve => {
 	const stream = eval('require')('stream'); // eslint-disable-line no-eval
 
 	readableStream.once('readable', () => {
 		const pass = new stream.PassThrough();
-		const chunk = readableStream.read(module.exports.minimumBytes);
+		const chunk = readableStream.read(module.exports.minimumBytes) || readableStream.read();
 		pass.fileType = module.exports(chunk);
 		readableStream.unshift(chunk);
 
-		// TODO: Use `stream.pipeline()` when targeting Node.js 10
 		resolve(readableStream.pipe(pass));
 	});
 });

--- a/index.js
+++ b/index.js
@@ -928,6 +928,7 @@ module.exports.stream = readableStream => new Promise(resolve => {
 		pass.fileType = module.exports(chunk);
 		readableStream.unshift(chunk);
 
+		// TODO: Use `stream.pipeline()` when targeting Node.js 10
 		resolve(readableStream.pipe(pass));
 	});
 });

--- a/index.js
+++ b/index.js
@@ -920,19 +920,15 @@ module.exports = input => {
 Object.defineProperty(module.exports, 'minimumBytes', {value: 4100});
 
 module.exports.stream = readableStream => new Promise((resolve, reject) => {
-	try {
-		const stream = eval('require')('stream'); // eslint-disable-line no-eval
+	const stream = eval('require')('stream'); // eslint-disable-line no-eval
 
-		readableStream.once('readable', () => {
-			const pass = new stream.PassThrough();
-			const chunk = readableStream.read(module.exports.minimumBytes);
-			pass.fileType = module.exports(chunk);
-			readableStream.unshift(chunk);
-			
-			// TODO: Use `stream.pipeline()` when targeting Node.js 10
-			resolve(readableStream.pipe(pass));
-		});
-	} catch (error) {
-		reject(error);
-	}
+	readableStream.once('readable', () => {
+		const pass = new stream.PassThrough();
+		const chunk = readableStream.read(module.exports.minimumBytes);
+		pass.fileType = module.exports(chunk);
+		readableStream.unshift(chunk);
+
+		// TODO: Use `stream.pipeline()` when targeting Node.js 10
+		resolve(readableStream.pipe(pass));
+	});
 });

--- a/index.js
+++ b/index.js
@@ -928,6 +928,8 @@ module.exports.stream = readableStream => new Promise((resolve, reject) => {
 			const chunk = readableStream.read(module.exports.minimumBytes);
 			pass.fileType = module.exports(chunk);
 			readableStream.unshift(chunk);
+			
+			// TODO: Use `stream.pipeline()` when targeting Node.js 10
 			resolve(readableStream.pipe(pass));
 		});
 	} catch (error) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,4 @@
 'use strict';
-
-const stream = require('stream');
-
 const toBytes = s => [...s].map(c => c.charCodeAt(0));
 const xpiZipFilename = toBytes('META-INF/mozilla.rsa');
 const oxmlContentTypes = toBytes('[Content_Types].xml');
@@ -924,6 +921,8 @@ Object.defineProperty(module.exports, 'minimumBytes', {value: 4100});
 
 module.exports.stream = readableStream => new Promise((resolve, reject) => {
 	try {
+		const stream = eval('require')('stream'); // eslint-disable-line no-eval
+
 		readableStream.once('readable', () => {
 			const pass = new stream.PassThrough();
 			const chunk = readableStream.read(module.exports.minimumBytes);

--- a/index.js
+++ b/index.js
@@ -918,3 +918,16 @@ module.exports = input => {
 };
 
 Object.defineProperty(module.exports, 'minimumBytes', {value: 4100});
+
+module.exports.stream = readableStream => new Promise(resolve => {
+	const stream = readableStream;
+
+	function helper(stream) {
+		const chunk = stream.read(module.exports.minimumBytes);
+		stream.fileType = module.exports(chunk);
+		stream.unshift(chunk);
+		resolve(stream);
+	}
+
+	stream.once('readable', () => helper(stream));
+});

--- a/index.js
+++ b/index.js
@@ -928,7 +928,10 @@ module.exports.stream = readableStream => new Promise(resolve => {
 		pass.fileType = module.exports(chunk);
 		readableStream.unshift(chunk);
 
-		// TODO: Use `stream.pipeline()` when targeting Node.js 10
-		resolve(readableStream.pipe(pass));
+		if (stream.pipeline) {
+			resolve(stream.pipeline(readableStream, pass));
+		} else {
+			resolve(readableStream.pipe(pass));
+		}
 	});
 });

--- a/index.js
+++ b/index.js
@@ -919,15 +919,15 @@ module.exports = input => {
 
 Object.defineProperty(module.exports, 'minimumBytes', {value: 4100});
 
-module.exports.stream = readableStream => new Promise(resolve => {
-	const stream = readableStream;
-
-	function helper(stream) {
-		const chunk = stream.read(module.exports.minimumBytes);
-		stream.fileType = module.exports(chunk);
-		stream.unshift(chunk);
-		resolve(stream);
+module.exports.stream = readableStream => new Promise((resolve, reject) => {
+	try {
+		readableStream.once('readable', () => {
+			const chunk = readableStream.read(module.exports.minimumBytes);
+			readableStream.fileType = module.exports(chunk);
+			readableStream.unshift(chunk);
+			resolve(readableStream);
+		});
+	} catch (error) {
+		reject(error);
 	}
-
-	stream.once('readable', () => helper(stream));
 });

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 'use strict';
+
+const stream = require('stream');
+
 const toBytes = s => [...s].map(c => c.charCodeAt(0));
 const xpiZipFilename = toBytes('META-INF/mozilla.rsa');
 const oxmlContentTypes = toBytes('[Content_Types].xml');
@@ -922,10 +925,11 @@ Object.defineProperty(module.exports, 'minimumBytes', {value: 4100});
 module.exports.stream = readableStream => new Promise((resolve, reject) => {
 	try {
 		readableStream.once('readable', () => {
+			const pass = new stream.PassThrough();
 			const chunk = readableStream.read(module.exports.minimumBytes);
-			readableStream.fileType = module.exports(chunk);
+			pass.fileType = module.exports(chunk);
 			readableStream.unshift(chunk);
-			resolve(readableStream);
+			resolve(readableStream.pipe(pass));
 		});
 	} catch (error) {
 		reject(error);

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
 	],
 	"devDependencies": {
 		"ava": "^1.0.1",
+		"pify": "^4.0.1",
 		"read-chunk": "^3.0.0",
 		"xo": "^0.23.0"
 	}

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,16 @@ Type: `number`
 
 The minimum amount of bytes needed to detect a file type. Currently, it's 4100 bytes, but it can change, so don't hardcode it.
 
+### fileType.stream(readableStream)
+
+Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property. For use with Node streams.
+
+#### readableStream
+
+Type: `Object`
+
+This is a Node readable stream, of class: [stream.Readable](https://nodejs.org/api/stream.html#stream_class_stream_readable).
+
 
 ## Supported file types
 

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,27 @@ http.get(url, response => {
 });
 ```
 
+Or from a stream:
+
+```js
+const fs = require('fs');
+const crypto = require('crypto');
+
+const read = fs.createReadStream('encrypted.enc');
+const decipher = crypto.createDecipheriv(alg, key, iv);
+
+const readableStream = fileType(read.pipe(decipher));
+
+readableStream.then(stream => {
+	console.log(stream.fileType);
+	//=> {ext: 'mov', mime: 'video/quicktime'}
+
+	const write = fs.createWriteStream(`decrypted.${stream.fileType.ext}`);
+	readableStream.pipe(write);
+});
+```
+
+
 ##### Browser
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ const crypto = require('crypto');
 const read = fs.createReadStream('encrypted.enc');
 const decipher = crypto.createDecipheriv(alg, key, iv);
 
-const readableStream = fileType(read.pipe(decipher));
+const readableStream = fileType.stream(read.pipe(decipher));
 
 readableStream.then(stream => {
 	console.log(stream.fileType);

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ Or from a stream:
 ```js
 const fs = require('fs');
 const crypto = require('crypto');
+const fileType = require('file-type');
 
 const read = fs.createReadStream('encrypted.enc');
 const decipher = crypto.createDecipheriv(alg, key, iv);

--- a/readme.md
+++ b/readme.md
@@ -89,13 +89,13 @@ The minimum amount of bytes needed to detect a file type. Currently, it's 4100 b
 
 ### fileType.stream(readableStream)
 
-Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property. For use with Node streams.
+Detect the file type of a readable stream.
+
+Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileType()`.
 
 #### readableStream
 
-Type: `Object`
-
-This is a Node readable stream, of class: [stream.Readable](https://nodejs.org/api/stream.html#stream_class_stream_readable).
+Type: [`stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
 
 
 ## Supported file types

--- a/test.js
+++ b/test.js
@@ -233,7 +233,7 @@ test('.stream() method', async t => {
 });
 
 test('.stream() method - identical streams', async t => {
-	const file = path.join(__dirname, 'fixture', 'fixture.mp3');
+	const file = path.join(__dirname, 'fixture', 'fixture.rtf');
 
 	const readableStream = await fileType.stream(fs.createReadStream(file));
 	const bufferA = [];
@@ -257,7 +257,6 @@ test('.stream() method - identical streams', async t => {
 		fileStream.on('end', resolve);
 	});
 
-	// TODO: Use `stream.finished()` when targeting Node.js 10
 	await Promise.all([promiseA, promiseB]);
 
 	t.true(Buffer.concat(bufferA).equals(Buffer.concat(bufferB)));

--- a/test.js
+++ b/test.js
@@ -221,6 +221,7 @@ const testStream = async (t, ext, name) => {
 		fileStream.on('end', resolve);
 	});
 
+	// TODO: Use `stream.finished()` when targeting Node.js 10
 	await Promise.all([promiseA, promiseB]);
 
 	t.true(Buffer.concat(bufferA).equals(Buffer.concat(bufferB)));

--- a/test.js
+++ b/test.js
@@ -257,6 +257,7 @@ test('.stream() method - identical streams', async t => {
 		fileStream.on('end', resolve);
 	});
 
+	// TODO: Use `stream.finished()` when targeting Node.js 10
 	await Promise.all([promiseA, promiseB]);
 
 	t.true(Buffer.concat(bufA).equals(Buffer.concat(bufB)));

--- a/test.js
+++ b/test.js
@@ -1,9 +1,8 @@
 import path from 'path';
+import fs from 'fs';
 import test from 'ava';
 import readChunk from 'read-chunk';
 import fileType from '.';
-
-const fs = require('fs');
 
 const check = (ext, name) => {
 	const file = path.join(__dirname, 'fixture', `${(name || 'fixture')}.${ext}`);
@@ -237,9 +236,11 @@ test('check identical stream', async t => {
 	const file = path.join(__dirname, 'fixture', 'fixture.mp3');
 
 	const readableStream = await fileType.stream(fs.createReadStream(file));
+	console.log(readableStream);
 	const bufA = [];
 
-	const fileStream = await fs.createReadStream(file);
+	const fileStream = fs.createReadStream(file);
+	console.log(fileStream);
 	const bufB = [];
 
 	readableStream.on('data', c => bufA.push(Buffer.from(c)));

--- a/test.js
+++ b/test.js
@@ -236,11 +236,9 @@ test('check identical stream', async t => {
 	const file = path.join(__dirname, 'fixture', 'fixture.mp3');
 
 	const readableStream = await fileType.stream(fs.createReadStream(file));
-	console.log(readableStream);
 	const bufA = [];
 
 	const fileStream = fs.createReadStream(file);
-	console.log(fileStream);
 	const bufB = [];
 
 	readableStream.on('data', c => bufA.push(Buffer.from(c)));

--- a/test.js
+++ b/test.js
@@ -225,14 +225,14 @@ test('validate the input argument type', t => {
 	});
 });
 
-test('check stream property', async t => {
+test('.stream() method', async t => {
 	const file = path.join(__dirname, 'fixture', 'fixture.mp3');
 	const readableStream = await fileType.stream(fs.createReadStream(file));
 
 	t.deepEqual(readableStream.fileType, fileType(readChunk.sync(file, 0, fileType.minimumBytes)));
 });
 
-test('check identical stream', async t => {
+test('.stream() method - identical streams', async t => {
 	const file = path.join(__dirname, 'fixture', 'fixture.mp3');
 
 	const readableStream = await fileType.stream(fs.createReadStream(file));
@@ -241,13 +241,23 @@ test('check identical stream', async t => {
 	const fileStream = fs.createReadStream(file);
 	const bufB = [];
 
-	readableStream.on('data', c => bufA.push(Buffer.from(c)));
-	fileStream.on('data', c => bufB.push(Buffer.from(c)));
+	readableStream.on('data', c => {
+		bufA.push(Buffer.from(c));
+	});
 
-	const promA = new Promise(resolve => readableStream.on('end', resolve));
-	const promB = new Promise(resolve => fileStream.on('end', resolve));
+	fileStream.on('data', c => {
+		bufB.push(Buffer.from(c));
+	});
 
-	await Promise.all([promA, promB]);
+	const promiseA = new Promise(resolve => {
+		readableStream.on('end', resolve);
+	});
+
+	const promiseB = new Promise(resolve => {
+		fileStream.on('end', resolve);
+	});
+
+	await Promise.all([promiseA, promiseB]);
 
 	t.true(Buffer.concat(bufA).equals(Buffer.concat(bufB)));
 });

--- a/test.js
+++ b/test.js
@@ -196,44 +196,8 @@ const testFile = (t, type, name) => {
 	t.is(check(type, name), type);
 };
 
-let i = 0;
-for (const type of types) {
-	if (Object.prototype.hasOwnProperty.call(names, type)) {
-		for (const name of names[type]) {
-			test(`${type} ${i++}`, testFile, type, name);
-		}
-	} else {
-		test(`${type} ${i++}`, testFile, type);
-	}
-}
-
-test('fileType.minimumBytes', t => {
-	t.true(fileType.minimumBytes > 4000);
-});
-
-test('validate the input argument type', t => {
-	t.throws(() => {
-		fileType('x');
-	}, /Expected the `input` argument to be of type `Uint8Array`/);
-
-	t.notThrows(() => {
-		fileType(Buffer.from('x'));
-	});
-
-	t.notThrows(() => {
-		fileType(new Uint8Array());
-	});
-});
-
-test('.stream() method', async t => {
-	const file = path.join(__dirname, 'fixture', 'fixture.mp3');
-	const readableStream = await fileType.stream(fs.createReadStream(file));
-
-	t.deepEqual(readableStream.fileType, fileType(readChunk.sync(file, 0, fileType.minimumBytes)));
-});
-
-test('.stream() method - identical streams', async t => {
-	const file = path.join(__dirname, 'fixture', 'fixture.rtf');
+const testStream = async (t, ext, name) => {
+	const file = path.join(__dirname, 'fixture', `${(name || 'fixture')}.${ext}`);
 
 	const readableStream = await fileType.stream(fs.createReadStream(file));
 	const bufferA = [];
@@ -260,4 +224,42 @@ test('.stream() method - identical streams', async t => {
 	await Promise.all([promiseA, promiseB]);
 
 	t.true(Buffer.concat(bufferA).equals(Buffer.concat(bufferB)));
+};
+
+let i = 0;
+for (const type of types) {
+	if (Object.prototype.hasOwnProperty.call(names, type)) {
+		for (const name of names[type]) {
+			test(`${type} ${i++}`, testFile, type, name);
+			test(`.stream() method - identical streams - ${type} ${i++}`, testStream, type, name);
+		}
+	} else {
+		test(`${type} ${i++}`, testFile, type);
+		test(`.stream() method - identical streams - ${type} ${i++}`, testStream, type);
+	}
+}
+
+test('fileType.minimumBytes', t => {
+	t.true(fileType.minimumBytes > 4000);
+});
+
+test('validate the input argument type', t => {
+	t.throws(() => {
+		fileType('x');
+	}, /Expected the `input` argument to be of type `Uint8Array`/);
+
+	t.notThrows(() => {
+		fileType(Buffer.from('x'));
+	});
+
+	t.notThrows(() => {
+		fileType(new Uint8Array());
+	});
+});
+
+test('.stream() method', async t => {
+	const file = path.join(__dirname, 'fixture', 'fixture.mp3');
+	const readableStream = await fileType.stream(fs.createReadStream(file));
+
+	t.deepEqual(readableStream.fileType, fileType(readChunk.sync(file, 0, fileType.minimumBytes)));
 });

--- a/test.js
+++ b/test.js
@@ -236,17 +236,17 @@ test('.stream() method - identical streams', async t => {
 	const file = path.join(__dirname, 'fixture', 'fixture.mp3');
 
 	const readableStream = await fileType.stream(fs.createReadStream(file));
-	const bufA = [];
+	const bufferA = [];
 
 	const fileStream = fs.createReadStream(file);
-	const bufB = [];
+	const bufferB = [];
 
 	readableStream.on('data', c => {
-		bufA.push(Buffer.from(c));
+		bufferA.push(Buffer.from(c));
 	});
 
 	fileStream.on('data', c => {
-		bufB.push(Buffer.from(c));
+		bufferB.push(Buffer.from(c));
 	});
 
 	const promiseA = new Promise(resolve => {
@@ -260,5 +260,5 @@ test('.stream() method - identical streams', async t => {
 	// TODO: Use `stream.finished()` when targeting Node.js 10
 	await Promise.all([promiseA, promiseB]);
 
-	t.true(Buffer.concat(bufA).equals(Buffer.concat(bufB)));
+	t.true(Buffer.concat(bufferA).equals(Buffer.concat(bufferB)));
 });


### PR DESCRIPTION
This PR adds a method to support Node streams without causing side effects on the state of the stream. It reads in the minimum amount of bytes to detect the filetype, detects the file type, then rolls back the stream for use elsewhere.

Fixes #186