### PR TITLE
Handle errors from `fileType.stream` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -941,6 +941,7 @@ module.exports.stream = readableStream => new Promise((resolve, reject) => {
 		} catch (error) {
 			reject(error);
 		}
+
 		readableStream.unshift(chunk);
 
 		if (stream.pipeline) {

--- a/index.js
+++ b/index.js
@@ -929,14 +929,18 @@ module.exports.default = fileType;
 
 Object.defineProperty(fileType, 'minimumBytes', {value: 4100});
 
-module.exports.stream = readableStream => new Promise(resolve => {
+module.exports.stream = readableStream => new Promise((resolve, reject) => {
 	// Using `eval` to work around issues when bundling with Webpack
 	const stream = eval('require')('stream'); // eslint-disable-line no-eval
 
 	readableStream.once('readable', () => {
 		const pass = new stream.PassThrough();
 		const chunk = readableStream.read(module.exports.minimumBytes) || readableStream.read();
-		pass.fileType = fileType(chunk);
+		try {
+			pass.fileType = fileType(chunk);
+		} catch (error) {
+			reject(error);
+		}
 		readableStream.unshift(chunk);
 
 		if (stream.pipeline) {

--- a/test.js
+++ b/test.js
@@ -247,6 +247,14 @@ for (const type of types) {
 	}
 }
 
+test('.stream() method - empty stream', async t => {
+	const emptyStream = fs.createReadStream('/dev/null');
+	await t.throwsAsync(
+		fileType.stream(emptyStream),
+		/Expected the `input` argument to be of type `Uint8Array` /
+	);
+});
+
 test('fileType.minimumBytes', t => {
 	t.true(fileType.minimumBytes > 4000);
 });


### PR DESCRIPTION
There are cases like an empty stream then fileType(chunk) will throw an error. The error is not propagated correctly and cannot be caught in the main plot. Using reject solves the problem and allows to handle error in the main plot of the app.
```js
try {
  fileTypeStream = await fileType.stream(stream);
} catch (error) {
  // without reject, you won't catch the error thrown by fileType(check) here
  console.log(error);
}
```