### PR TITLE
Run travis CI also on Node.js 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '11'
   - '10'
   - '8'
   - '6'


### PR DESCRIPTION
As of https://github.com/sindresorhus/file-type/pull/198, file-type should also work on Node.js 11.
Running the tests on Node.js 11 would verify that.