### PR TITLE
Fix `mp2`/`mp3` checks to not catch `mp1`

### DIFF
--- a/index.js
+++ b/index.js
@@ -421,7 +421,7 @@ const fileType = input => {
 	for (let start = 0; start < 2 && start < (buf.length - 16); start++) {
 		if (
 			check([0x49, 0x44, 0x33], {offset: start}) || // ID3 header
-			check([0xFF, 0xE2], {offset: start, mask: [0xFF, 0xE2]}) // MPEG 1 or 2 Layer 3 header
+			check([0xFF, 0xE2], {offset: start, mask: [0xFF, 0xE6]}) // MPEG 1 or 2 Layer 3 header
 		) {
 			return {
 				ext: 'mp3',
@@ -430,7 +430,7 @@ const fileType = input => {
 		}
 
 		if (
-			check([0xFF, 0xE4], {offset: start, mask: [0xFF, 0xE4]}) // MPEG 1 or 2 Layer 2 header
+			check([0xFF, 0xE4], {offset: start, mask: [0xFF, 0xE6]}) // MPEG 1 or 2 Layer 2 header
 		) {
 			return {
 				ext: 'mp2',


### PR DESCRIPTION
Subject.

Anyhow, checks for mp2/mp3 were incorrect and actually caught also mp1, so I fixed that.

As for mp1, mpeg 1 layer 1 crc protected collides with utf16 BOM and there is no other markers, also rarely used. Current `file` sources ignore it for that reason.

@sindresorhus Also, the whole mp2/3 part is kinda weird. 
- it is a stream, yes, and can be resumed, but it's weird to do that for the purpose of file type detection, as you can detect any file with embedded mp3 incorrectly. (libmagic doesn't do that for example)
- even if there is no embedded mp3,the stream is well compressed and matching those simple checks at arbitrary offsets will bring false positives on most files around
- checking just offsets 0 and 1 is completely counter-intuitive, it should be either all reachable offsets or just the start, otherwise it's just asking for hard to debug bugs
- ID3 part doesn't belong there, ID3v2 is embedded either at beginning or end of file

Fixes #163