### PR TITLE
Skip unit test using /dev/null on Windows platforms.

### DIFF
--- a/test.js
+++ b/test.js
@@ -247,13 +247,15 @@ for (const type of types) {
 	}
 }
 
-test('.stream() method - empty stream', async t => {
-	const emptyStream = fs.createReadStream('/dev/null');
-	await t.throwsAsync(
-		fileType.stream(emptyStream),
-		/Expected the `input` argument to be of type `Uint8Array` /
-	);
-});
+if (process.platform !== 'win32') {
+	test('.stream() method - empty stream', async t => {
+		const emptyStream = fs.createReadStream('/dev/null');
+		await t.throwsAsync(
+			fileType.stream(emptyStream),
+			/Expected the `input` argument to be of type `Uint8Array` /
+		);
+	});
+}
 
 test('fileType.minimumBytes', t => {
 	t.true(fileType.minimumBytes > 4000);


### PR DESCRIPTION
Windows has not such thing as `'/dev/null'`, therefor skip this test on Windows.
This also works on 64-bit architecture.
