### PR TITLE
Fix handling of Uint8Array and ArrayBuffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const {stringToBytes, readUInt64LE, tarHeaderChecksumMatches} = require('./util');
+const {stringToBytes, readUInt64LE, tarHeaderChecksumMatches, uint8ArrayUtf8ByteString} = require('./util');
 
 const xpiZipFilename = stringToBytes('META-INF/mozilla.rsa');
 const oxmlContentTypes = stringToBytes('[Content_Types].xml');
@@ -289,7 +289,7 @@ const fileType = input => {
 	) {
 		// They all can have MIME `video/mp4` except `application/mp4` special-case which is hard to detect.
 		// For some cases, we're specific, everything else falls to `video/mp4` with `mp4` extension.
-		const brandMajor = buffer.toString('utf8', 8, 12);
+		const brandMajor = uint8ArrayUtf8ByteString(buffer, 8, 12);
 		switch (brandMajor) {
 			case 'mif1':
 				return {ext: 'heic', mime: 'image/heif'};

--- a/test.js
+++ b/test.js
@@ -6,11 +6,6 @@ import readChunk from 'read-chunk';
 import pify from 'pify';
 import fileType from '.';
 
-const check = (ext, name) => {
-	const file = path.join(__dirname, 'fixture', `${(name || 'fixture')}.${ext}`);
-	return fileType(readChunk.sync(file, 0, 4 + 4096)) || {};
-};
-
 const types = [
 	'jpg',
 	'png',
@@ -209,10 +204,18 @@ const names = {
 	]
 };
 
-const testFile = (t, type, name) => {
-	const {ext, mime} = check(type, name);
+const checkBufferLike = (t, type, bufferLike) => {
+	const {ext, mime} = fileType(bufferLike) || {};
 	t.is(ext, type);
 	t.is(typeof mime, 'string');
+};
+
+const testFile = (t, ext, name) => {
+	const file = path.join(__dirname, 'fixture', `${(name || 'fixture')}.${ext}`);
+	const chunk = readChunk.sync(file, 0, 4 + 4096);
+	checkBufferLike(t, ext, chunk);
+	checkBufferLike(t, ext, new Uint8Array(chunk));
+	checkBufferLike(t, ext, chunk.buffer);
 };
 
 const testFileFromStream = async (t, ext, name) => {

--- a/util.js
+++ b/util.js
@@ -2,6 +2,10 @@
 
 exports.stringToBytes = string => [...string].map(character => character.charCodeAt(0));
 
+const uint8ArrayUtf8ByteString = (array, start, end) => {
+	return String.fromCharCode(...array.slice(start, end));
+};
+
 exports.readUInt64LE = (buffer, offset = 0) => {
 	let n = buffer[offset];
 	let mul = 1;
@@ -39,7 +43,7 @@ exports.tarHeaderChecksumMatches = buffer => { // Does not check if checksum fie
 		signedBitSum += byte & MASK_8TH_BIT; // Add signed bit to signed bit sum
 	}
 
-	const readSum = parseInt(buffer.toString('utf8', 148, 154), 8); // Read sum in header
+	const readSum = parseInt(uint8ArrayUtf8ByteString(buffer, 148, 154), 8); // Read sum in header
 
 	// Some implementations compute checksum incorrectly using signed bytes
 	return (
@@ -50,3 +54,5 @@ exports.tarHeaderChecksumMatches = buffer => { // Does not check if checksum fie
 		readSum === (sum - (signedBitSum << 1))
 	);
 };
+
+exports.uint8ArrayUtf8ByteString = uint8ArrayUtf8ByteString;


### PR DESCRIPTION
So, while looking into #211, I've realized I've made a system mistake of handling only buffers in a couple of patches which is not covered by tests(it is not producing any errors, just incorrect internal value hence result). Here are updates to tests to catch such mistakes in the future and code to fix it.

It is supposed to fix #211.