### PR TITLE
Reject on stream error events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1017,6 +1017,7 @@ fileType.stream = readableStream => new Promise((resolve, reject) => {
 	// Using `eval` to work around issues when bundling with Webpack
 	const stream = eval('require')('stream'); // eslint-disable-line no-eval
 
+	readableStream.on('error', reject);
 	readableStream.once('readable', () => {
 		const pass = new stream.PassThrough();
 		const chunk = readableStream.read(module.exports.minimumBytes) || readableStream.read();

--- a/test.js
+++ b/test.js
@@ -296,6 +296,17 @@ test('.stream() method - empty stream', async t => {
 	);
 });
 
+test('.stream() method - error event', async t => {
+	const errMsg = 'Demo read error';
+	const rStream = new stream.Readable({
+		read() {
+			process.nextTick(() => this.emit('error', new Error(errMsg)));
+		}
+	});
+
+	await t.throwsAsync(fileType.stream(rStream), errMsg);
+});
+
 test('fileType.minimumBytes', t => {
 	t.true(fileType.minimumBytes > 4000);
 });

--- a/test.js
+++ b/test.js
@@ -297,14 +297,17 @@ test('.stream() method - empty stream', async t => {
 });
 
 test('.stream() method - error event', async t => {
-	const errMsg = 'Demo read error';
-	const rStream = new stream.Readable({
+	const errorMessage = 'Fixture';
+
+	const readableStream = new stream.Readable({
 		read() {
-			process.nextTick(() => this.emit('error', new Error(errMsg)));
+			process.nextTick(() => {
+				this.emit('error', new Error(errorMessage));
+			});
 		}
 	});
 
-	await t.throwsAsync(fileType.stream(rStream), errMsg);
+	await t.throwsAsync(fileType.stream(readableStream), errorMessage);
 });
 
 test('fileType.minimumBytes', t => {


### PR DESCRIPTION
Previously the .stream method would not reject if an error happened.
This could cause the promise to never resolve and thus could cause
hangs. This fixes that by rejecting whenever an error event happens.