### PR TITLE
Improve performance of the ZIP check

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const fileType = input => {
 		throw new TypeError(`Expected the \`input\` argument to be of type \`Uint8Array\` or \`Buffer\` or \`ArrayBuffer\`, got \`${typeof input}\``);
 	}
 
-	const buffer = input instanceof Uint8Array ? input : new Uint8Array(input);
+	const buffer = Buffer.from(input);
 
 	if (!(buffer && buffer.length > 1)) {
 		return;
@@ -191,7 +191,8 @@ const fileType = input => {
 
 	// Zip-based file formats
 	// Need to be before the `zip` check
-	if (check([0x50, 0x4B, 0x3, 0x4])) {
+	const zipHeader = Buffer.from([0x50, 0x4B, 0x3, 0x4]);
+	if (check(zipHeader)) {
 		if (
 			check([0x6D, 0x69, 0x6D, 0x65, 0x74, 0x79, 0x70, 0x65, 0x61, 0x70, 0x70, 0x6C, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6F, 0x6E, 0x2F, 0x65, 0x70, 0x75, 0x62, 0x2B, 0x7A, 0x69, 0x70], {offset: 30})
 		) {
@@ -236,7 +237,7 @@ const fileType = input => {
 		// - one entry named '[Content_Types].xml' or '_rels/.rels',
 		// - one entry indicating specific type of file.
 		// MS Office, OpenOffice and LibreOffice may put the parts in different order, so the check should not rely on it.
-		const findNextZipHeaderIndex = (arr, startAt = 0) => arr.findIndex((el, i, arr) => i >= startAt && arr[i] === 0x50 && arr[i + 1] === 0x4B && arr[i + 2] === 0x3 && arr[i + 3] === 0x4);
+		const findNextZipHeaderIndex = (buf, startAt = 0) => buf.indexOf(zipHeader, startAt);
 
 		let zipHeaderIndex = 0; // The first zip header was already found at index 0
 		let oxmlFound = false;

--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ const fileType = input => {
 		// - one entry named '[Content_Types].xml' or '_rels/.rels',
 		// - one entry indicating specific type of file.
 		// MS Office, OpenOffice and LibreOffice may put the parts in different order, so the check should not rely on it.
-		const findNextZipHeaderIndex = (buf, startAt = 0) => buf.indexOf(zipHeader, startAt);
+		const findNextZipHeaderIndex = (buffer, startAt = 0) => buffer.indexOf(zipHeader, startAt);
 
 		let zipHeaderIndex = 0; // The first zip header was already found at index 0
 		let oxmlFound = false;


### PR DESCRIPTION
Closes #226

Changed `findNextZipHeaderIndex` function to use one `Buffer.indexOf` call instead of `Uint8Array.findIndex`, which calls the passed function for each byte. For this to work, I changed the `buffer` variable type to `Buffer`. It extends `Uint8Array`, but it does not copy data, so it does not have any memory impact.

Btw, there is `indexOf` method on `Uint8Array` type, but it only allows for single byte searching, not a byte sequence.

Tested on this file https://imagemagick.org/download/windows/releases/ImageMagick-6.9.10-33.zip
Result: processing time drop from several hours (I stopped it after 90 minutes) to 84 milliseconds.
My setup: MacBook Pro, Intel Core I7 2,2 GHz, node 12.5.0.
