### PR TITLE
Make Buffer usage optional again

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,14 @@ const {stringToBytes, readUInt64LE, tarHeaderChecksumMatches, uint8ArrayUtf8Byte
 const xpiZipFilename = stringToBytes('META-INF/mozilla.rsa');
 const oxmlContentTypes = stringToBytes('[Content_Types].xml');
 const oxmlRels = stringToBytes('_rels/.rels');
+const zipHeader = [0x50, 0x4B, 0x3, 0x4];
 
 const fileType = input => {
 	if (!(input instanceof Uint8Array || input instanceof ArrayBuffer || Buffer.isBuffer(input))) {
 		throw new TypeError(`Expected the \`input\` argument to be of type \`Uint8Array\` or \`Buffer\` or \`ArrayBuffer\`, got \`${typeof input}\``);
 	}
 
-	const buffer = Buffer.from(input);
+	const buffer = input instanceof Uint8Array ? input : new Uint8Array(input);
 
 	if (!(buffer && buffer.length > 1)) {
 		return;
@@ -191,7 +192,6 @@ const fileType = input => {
 
 	// Zip-based file formats
 	// Need to be before the `zip` check
-	const zipHeader = Buffer.from([0x50, 0x4B, 0x3, 0x4]);
 	if (check(zipHeader)) {
 		if (
 			check([0x6D, 0x69, 0x6D, 0x65, 0x74, 0x79, 0x70, 0x65, 0x61, 0x70, 0x70, 0x6C, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6F, 0x6E, 0x2F, 0x65, 0x70, 0x75, 0x62, 0x2B, 0x7A, 0x69, 0x70], {offset: 30})
@@ -237,7 +237,23 @@ const fileType = input => {
 		// - one entry named '[Content_Types].xml' or '_rels/.rels',
 		// - one entry indicating specific type of file.
 		// MS Office, OpenOffice and LibreOffice may put the parts in different order, so the check should not rely on it.
-		const findNextZipHeaderIndex = (buffer, startAt = 0) => buffer.indexOf(zipHeader, startAt);
+		const findNextZipHeaderIndex = (buffer, startAt = 0) => {
+			if (Buffer && Buffer.isBuffer(buffer)) {
+				return buffer.indexOf(Buffer.from(zipHeader), startAt);
+			}
+
+			// Uint8Array.indexOf, unlike Buffer.indexOf, can search for single byte only
+			let index = buffer.indexOf(zipHeader[0], startAt);
+			while (index >= 0) {
+				if (check(zipHeader, {offset: index})) {
+					return index;
+				}
+
+				index = buffer.indexOf(zipHeader[0], index + 1);
+			}
+
+			return -1;
+		};
 
 		let zipHeaderIndex = 0; // The first zip header was already found at index 0
 		let oxmlFound = false;

--- a/util.js
+++ b/util.js
@@ -55,4 +55,33 @@ exports.tarHeaderChecksumMatches = buffer => { // Does not check if checksum fie
 	);
 };
 
+exports.multiByteIndexOf = (buffer, bytes, startAt = 0) => {
+	// Buffer.indexOf can find multiple bytes itself
+	if (Buffer && Buffer.isBuffer(buffer)) {
+		return buffer.indexOf(Buffer.from(bytes), startAt);
+	}
+
+	const nextBytesMatch = (buffer, bytes, startIndex) => {
+		for (let i = 1; i < bytes.length; i++) {
+			if (bytes[i] !== buffer[startIndex + i]) {
+				return false;
+			}
+		}
+
+		return true;
+	};
+
+	// Uint8Array.indexOf can search for single byte only
+	let index = buffer.indexOf(bytes[0], startAt);
+	while (index >= 0) {
+		if (nextBytesMatch(buffer, bytes, index)) {
+			return index;
+		}
+
+		index = buffer.indexOf(bytes[0], index + 1);
+	}
+
+	return -1;
+};
+
 exports.uint8ArrayUtf8ByteString = uint8ArrayUtf8ByteString;


### PR DESCRIPTION
Related to #227 and [a comment about browser usage](https://github.com/sindresorhus/file-type/pull/227#issuecomment-517741187).

This PR makes usage of `Buffer` optional. If input type is `Buffer`, zip header searching is conducted with much faster `Buffer.indexOf`, otherwise single-byte `Uint8Array.indexOf` is used, which results in many false positives that must be discarded. Thus using `Buffer` type as input is still the best option in terms of speed and memory usage.

Tested on [the same 169MB .zip file as before](https://imagemagick.org/download/windows/releases/ImageMagick-6.9.10-33.zip), resulting in 49ms with `Buffer` and 465ms without `Buffer`.