### PR TITLE
add plugin support

### DIFF
--- a/test.js
+++ b/test.js
@@ -238,6 +238,19 @@ test('fileType.mimeTypes.has', t => {
 	t.false(fileType.mimeTypes.has('video/blah'));
 });
 
+test('fileType.plugin', t => {
+	fileType.plugin('test', (_, ctx) => {
+		if (ctx.check([0x87, 0x88, 0x89, 0x90])) {
+			return {
+				ext: 'test',
+				mime: 'application/test'
+			};
+		}
+	});
+	const result = fileType(new Uint8Array([0x87, 0x88, 0x89, 0x90]));
+	t.true(result && result.ext === 'test');
+});
+
 test('validate the input argument type', t => {
 	t.throws(() => {
 		fileType('x');


### PR DESCRIPTION
## Description

Complex type judgments may be used by very few people, and add them into the main code can lead to performance degradation for most users.

This PR adds a method that make user to check complex type by plugin.

## Demo

```
fileType.plugin('test', (_, ctx) => {
	if (ctx.check([0x87, 0x88, 0x89, 0x90])) {
		return {
			ext: 'test',
			mime: 'application/test'
		};
	}
});
const result = fileType(new Uint8Array([0x87, 0x88, 0x89, 0x90]));
```