### PR TITLE
Initial integration with strtok3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "file-type",
-	"version": "12.3.1",
+	"version": "12.4.0",
 	"description": "Detect the file type of a Buffer/Uint8Array/ArrayBuffer",
 	"license": "MIT",
 	"repository": "sindresorhus/file-type",
@@ -168,5 +168,8 @@
 		"read-chunk": "^3.2.0",
 		"tsd": "^0.7.1",
 		"xo": "^0.24.0"
+	},
+	"dependencies": {
+		"strtok3": "^3.1.1"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -11,26 +11,51 @@ The file type is detected by checking the [magic number](https://en.wikipedia.or
 $ npm install file-type
 ```
 
-
 ## Usage
+
+❗️ Please be aware, the API changed, to support smarter and more specialized methods to determine the file type ❗️
 
 ##### Node.js
 
+Determine file type from a file:
 ```js
-const readChunk = require('read-chunk');
-const fileType = require('file-type');
+import FileType from 'file-type';
 
-const buffer = readChunk.sync('unicorn.png', 0, fileType.minimumBytes);
+(async () => {
+    const fileType = await FileType.fromFile('/home/borewit/Pictures/background.png');
+    // fileType = {ext: 'png', mime: 'image/png'}
+})();
+```
 
-fileType(buffer);
-//=> {ext: 'png', mime: 'image/png'}
+Determine file type from a Buffer, which may be a portion of the beginning of a file.
+```js
+import FileType from 'file-type';
+import readChunk from 'read-chunk';
+
+(async () => {
+    const buffer = readChunk.sync('unicorn.png', 0, fileType.minimumBytes);
+    const fileType = await FileType.fromBuffer(buffer);
+    // fileType = {ext: 'png', mime: 'image/png'}
+})();
+```
+
+Determine file type from a stream
+```js
+import FileType from 'file-type';
+import fs from 'fs';
+
+(async () => {
+    const stream = fs.createReadStream('/Users/adam/myFile.mp4');
+    const fileType = await FileType.fromStream(stream);
+    // fileType = {ext: 'mp4', mime: 'image/mp4'}
+)();
 ```
 
 Or from a remote location:
 
 ```js
-const http = require('http');
-const fileType = require('file-type');
+import FileType from 'file-type';
+import http from 'http';
 
 const url = 'https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif';
 
@@ -39,7 +64,7 @@ http.get(url, response => {
 		const chunk = response.read(fileType.minimumBytes);
 		response.destroy();
 
-		console.log(fileType(chunk));
+		console.log(FileType.fromBuffer(chunk)); // ToDo change to stream
 		//=> {ext: 'gif', mime: 'image/gif'}
 	});
 });
@@ -57,7 +82,7 @@ const fileType = require('file-type');
 	const read = fs.createReadStream('encrypted.enc');
 	const decipher = crypto.createDecipheriv(alg, key, iv);
 
-	const fileTypeStream = await fileType.stream(stream.pipeline(read, decipher));
+	const fileTypeStream = await FileType.stream(stream.pipeline(read, decipher));
 
 	console.log(fileTypeStream.fileType);
 	//=> {ext: 'mov', mime: 'video/quicktime'}
@@ -70,17 +95,15 @@ const fileType = require('file-type');
 
 ##### Browser
 
+Will be moved to a module with specialized browser methods:
+
 ```js
-const xhr = new XMLHttpRequest();
-xhr.open('GET', 'unicorn.png');
-xhr.responseType = 'arraybuffer';
+import FileType from 'file-type-browser'; // ToDo
 
-xhr.onload = () => {
-	fileType(new Uint8Array(this.response));
-	//=> {ext: 'png', mime: 'image/png'}
-};
 
-xhr.send();
+FileType.parseBlob(); // ToDo
+
+FileType.parseStream(); // ToDo
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ import test from 'ava';
 import readChunk from 'read-chunk';
 import pify from 'pify';
 import {readableNoopStream} from 'noop-stream';
-import fileType from '.';
+import FileType from '.';
 
 const supported = require('./supported');
 
@@ -137,40 +137,52 @@ const falsePositives = {
 	]
 };
 
-const checkBufferLike = (t, type, bufferLike) => {
-	const {ext, mime} = fileType(bufferLike) || {};
+async function checkBufferLike(t, type, bufferLike) {
+	const {ext, mime} = await FileType.fromBuffer(bufferLike) || {};
 	t.is(ext, type);
 	t.is(typeof mime, 'string');
-};
+}
 
-const testFile = (t, ext, name) => {
+async function checkFile(t, type, filePath) {
+	const {ext, mime} = await FileType.fromFile(filePath) || {};
+	t.is(ext, type);
+	t.is(typeof mime, 'string');
+}
+
+async function testFromFile(t, ext, name) {
+	const file = path.join(__dirname, 'fixture', `${(name || 'fixture')}.${ext}`);
+	return checkFile(t, ext, file);
+}
+
+async function testFromBuffer(t, ext, name) {
 	const file = path.join(__dirname, 'fixture', `${(name || 'fixture')}.${ext}`);
 	const chunk = readChunk.sync(file, 0, 4 + 4096);
-	checkBufferLike(t, ext, chunk);
-	checkBufferLike(t, ext, new Uint8Array(chunk));
-	checkBufferLike(t, ext, chunk.buffer);
-};
+	await checkBufferLike(t, ext, chunk);
+	await checkBufferLike(t, ext, new Uint8Array(chunk));
+	await checkBufferLike(t, ext, chunk.buffer);
+}
 
-const testFalsePositive = (t, ext, name) => {
+const testFalsePositive = async (t, ext, name) => {
 	const file = path.join(__dirname, 'fixture', `${name}.${ext}`);
 	const chunk = readChunk.sync(file, 0, 4 + 4096);
 
-	t.is(fileType(chunk), undefined);
-	t.is(fileType(new Uint8Array(chunk)), undefined);
-	t.is(fileType(chunk.buffer), undefined);
+	t.is(await FileType.fromBuffer(chunk), undefined);
+	t.is(await FileType.fromBuffer(new Uint8Array(chunk)), undefined);
+	t.is(await FileType.fromBuffer(chunk.buffer), undefined);
 };
 
 const testFileFromStream = async (t, ext, name) => {
 	const file = path.join(__dirname, 'fixture', `${(name || 'fixture')}.${ext}`);
-	const readableStream = await fileType.stream(fs.createReadStream(file));
+	const readableStream = await FileType.stream(fs.createReadStream(file));
 
-	t.deepEqual(readableStream.fileType, fileType(readChunk.sync(file, 0, fileType.minimumBytes)));
+	const _fileType = await FileType.fromBuffer(readChunk.sync(file, 0, FileType.minimumBytes));
+	t.deepEqual(readableStream.fileType, _fileType);
 };
 
 const testStream = async (t, ext, name) => {
 	const file = path.join(__dirname, 'fixture', `${(name || 'fixture')}.${ext}`);
 
-	const readableStream = await fileType.stream(fs.createReadStream(file));
+	const readableStream = await FileType.stream(fs.createReadStream(file));
 	const fileStream = fs.createReadStream(file);
 
 	const loadEntireFile = async readable => {
@@ -198,14 +210,16 @@ let i = 0;
 for (const type of types) {
 	if (Object.prototype.hasOwnProperty.call(names, type)) {
 		for (const name of names[type]) {
-			test(`${type} ${i++}`, testFile, type, name);
-			test(`.stream() method - same fileType - ${type} ${i++}`, testFileFromStream, type, name);
-			test(`.stream() method - identical streams - ${type} ${i++}`, testStream, type, name);
+			test(`${type} ${i++} .fromFile()`, testFromFile, type, name);
+			test(`${type} ${i++} .fromBuffer()`, testFromBuffer, type, name);
+			test(`${type} ${i++} .stream() - same fileType`, testFileFromStream, type, name);
+			test(`${type} ${i++} .stream() - identical streams`, testStream, type, name);
 		}
 	} else {
-		test(`${type} ${i++}`, testFile, type);
-		test(`.stream() method - same fileType - ${type} ${i++}`, testFileFromStream, type);
-		test(`.stream() method - identical streams - ${type} ${i++}`, testStream, type);
+		test(`${type} ${i++} .fromFile()`, testFromFile, type);
+		test(`${type} ${i++} .fromBuffer()`, testFromBuffer, type);
+		test(`${type} ${i++} .stream() method - same fileType`, testFileFromStream, type);
+		test(`${type} ${i++} .stream() - identical streams`, testStream, type);
 	}
 
 	if (Object.prototype.hasOwnProperty.call(falsePositives, type)) {
@@ -217,7 +231,7 @@ for (const type of types) {
 
 test('.stream() method - empty stream', async t => {
 	await t.throwsAsync(
-		fileType.stream(readableNoopStream()),
+		FileType.stream(readableNoopStream()),
 		/Expected the `input` argument to be of type `Uint8Array` /
 	);
 });
@@ -233,38 +247,38 @@ test('.stream() method - error event', async t => {
 		}
 	});
 
-	await t.throwsAsync(fileType.stream(readableStream), errorMessage);
+	await t.throwsAsync(FileType.stream(readableStream), errorMessage);
 });
 
 test('fileType.minimumBytes', t => {
-	t.true(fileType.minimumBytes > 4000);
+	t.true(FileType.minimumBytes > 4000);
 });
 
 test('fileType.extensions.has', t => {
-	t.true(fileType.extensions.has('jpg'));
-	t.false(fileType.extensions.has('blah'));
+	t.true(FileType.extensions.has('jpg'));
+	t.false(FileType.extensions.has('blah'));
 });
 
 test('fileType.mimeTypes.has', t => {
-	t.true(fileType.mimeTypes.has('video/mpeg'));
-	t.false(fileType.mimeTypes.has('video/blah'));
+	t.true(FileType.mimeTypes.has('video/mpeg'));
+	t.false(FileType.mimeTypes.has('video/blah'));
 });
 
-test('validate the input argument type', t => {
-	t.throws(() => {
-		fileType('x');
+test('validate the input argument type', async t => {
+	await t.throwsAsync(async () => {
+		await FileType.fromBuffer('x');
 	}, /Expected the `input` argument to be of type `Uint8Array`/);
 
-	t.notThrows(() => {
-		fileType(Buffer.from('x'));
+	await t.notThrowsAsync(async () => {
+		await FileType.fromBuffer(Buffer.from('x'));
 	});
 
-	t.notThrows(() => {
-		fileType(new Uint8Array());
+	await t.notThrowsAsync(async () => {
+		await FileType.fromBuffer(new Uint8Array());
 	});
 
-	t.notThrows(() => {
-		fileType(new ArrayBuffer());
+	await t.notThrowsAsync(async () => {
+		await FileType.fromBuffer(new ArrayBuffer());
 	});
 });
 


### PR DESCRIPTION
Implementation of [*Change proposal: break the fixed sample limit* #248](https://github.com/sindresorhus/file-type/issues/248).

Initial integration with [strtok3](https://github.com/Borewit/strtok3), allowing the parser to read from the _tokenizer_.

The _tokenizer_ breaks the fixed buffer limitation, allowing as little, or as much data to be read to determine the file-type.

This PR:

1. Drafts the methods for node.js API.
2. Integrates with [strtok3](https://github.com/Borewit/strtok3)
3. Proof backwards compatibility: all unit tests passes

To be done:
1. Utilize the tokenizer in the `fromTokenizer()` method. (This will give the added value)
2. Update TypeScript definitions
3. Utilize the tokenizer instead of fixed buffer, in the _stream()_ method, this requires a kind of _teeing_ the input stream. I expect this to be very tricky.