### PR TITLE
Add Node.js script to analyze single file

### DIFF
--- a/type.js
+++ b/type.js
@@ -1,0 +1,20 @@
+#!/usr/bin/node
+const fs = require('fs');
+
+const fileType = require('.');
+
+if (process.argv.length !== 3) {
+	console.error('Expected path of the file to examine');
+	process.exit();
+}
+
+const file2test = process.argv[2];
+
+const type = fileType(fs.readFileSync(file2test));
+
+if (type) {
+	console.log(`MIME-type: ${type.mime}`);
+	console.log(`Extension: ${type.ext}`);
+} else {
+	console.log('Could not determine file type.');
+}


### PR DESCRIPTION
Add a script helps during development to parse a single file or fixture.
```sh
cd file-type
./type.js fixture\fixture.m4a
```
outputs:
```
Parsing: fixture\fixture.m4a
MIME-type: audio/x-m4a
extension: m4a
```

This allows to focus on debugging a single file type.