### PR TITLE
Use tokenizer browser

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -1,0 +1,15 @@
+import * as core from './core';
+
+/**
+ * Determine file type from ReadableStream
+ * @param stream - ReadableStream: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
+ * @return Promise with file-type
+ */
+export declare function fromStream(stream: ReadableStream): Promise<core.FileType>;
+
+/**
+ * Determine file type from Blob
+ * @param blob - Blob to parse: https://developer.mozilla.org/en-US/docs/Web/API/Blob
+ * @returns Promise with file-type
+ */
+export declare function fromeBlob(blob: Blob): Promise<core.FileType>;

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,50 @@
+'use strict';
+const {ReadableWebToNodeStream} = require('readable-web-to-node-stream');
+const toBuffer = require('typedarray-to-buffer');
+const core = require('./core');
+
+async function fromStream(stream) {
+	const readableWebToNodeStream = new ReadableWebToNodeStream(stream);
+	const fileType = await core.fromStream(readableWebToNodeStream);
+	await readableWebToNodeStream.close();
+	return fileType;
+}
+
+async function fromBlob(blob) {
+	const buf = await convertBlobToBuffer(blob);
+	return core.fromBuffer(buf);
+}
+
+/**
+ * Convert Web API File to Node Buffer
+ * @param {Blob} blob Web API Blob
+ * @return {Promise<Buffer>}
+ */
+function convertBlobToBuffer(blob) {
+	return new Promise((resolve, reject) => {
+		const fileReader = new FileReader();
+		fileReader.addEventListener('loadend', event => {
+			let data = event.target.result;
+			if (data instanceof ArrayBuffer) {
+				data = toBuffer(new Uint8Array(event.target.result));
+			}
+
+			resolve(data);
+		});
+
+		fileReader.addEventListener('error', event => {
+			reject(new Error(event.message));
+		});
+
+		fileReader.addEventListener('abort', event => {
+			reject(new Error(event.type));
+		});
+
+		fileReader.readAsArrayBuffer(blob);
+	});
+}
+
+Object.assign(module.exports, core, {
+	fromStream,
+	fromBlob
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	"files": [
 		"index.js",
 		"index.d.ts",
+		"browser.js",
 		"core.js",
 		"core.d.ts",
 		"supported.js",
@@ -172,10 +173,16 @@
 		"xo": "^0.24.0"
 	},
 	"dependencies": {
+		"readable-web-to-node-stream": "^2.0.0",
 		"strtok3": "^3.1.1",
-		"token-types": "^1.1.0"
+		"token-types": "^1.1.0",
+		"typedarray-to-buffer": "^3.1.5"
 	},
 	"xo": {
+		"envs": [
+			"node",
+			"browser"
+		],
 		"rules": {
 			"no-inner-declarations": 1,
 			"no-await-in-loop": 1,

--- a/readme.md
+++ b/readme.md
@@ -98,12 +98,12 @@ const fileType = require('file-type');
 Will be moved to a module with specialized browser methods:
 
 ```js
-import FileType from 'file-type-browser'; // ToDo
+const FileType = require('file-type/browser');
 
 
-fileType.parseBlob(); // ToDo
+FileType.parseBlob(); // ToDo
 
-fileType.parseStream(); // ToDo
+FileType.parseStream(); // ToDo
 ```
 
 


### PR DESCRIPTION
Part of implementation of #248

Add browser specific functions.

Get file type based on content from [Web API ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream):

```js
const FileType = require('file-type/browser');
(async () => {

    const response = await fetch("https://www.example.org/");
    const fileType = await FileType.fromStream(response.body);
})();

```

Get file type based on content from [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob):

```js
const FileType = require('file-type/browser');
(async () => {
    const fileType = await FileType.fromBlob(blob);
})();
```