### PR TITLE
Fix `extensions` and `mimeTypes` TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -296,7 +296,7 @@ declare const fileType: {
 	/**
 	Supported file extensions.
 	*/
-	readonly extensions: ReadonlyArray<fileType.FileType>;
+	readonly extensions: readonly fileType.FileType[];
 
 	/**
 	Supported MIME types.

--- a/index.d.ts
+++ b/index.d.ts
@@ -301,7 +301,7 @@ declare const fileType: {
 	/**
 	Supported MIME types.
 	*/
-	readonly mimeTypes: ReadonlyArray<fileType.MimeType>;
+	readonly mimeTypes: readonly fileType.MimeType[];
 
 	/**
 	Detect the file type of a readable stream.

--- a/index.d.ts
+++ b/index.d.ts
@@ -296,12 +296,12 @@ declare const fileType: {
 	/**
 	Supported file extensions.
 	*/
-	readonly extensions: fileType.FileType;
+	readonly extensions: ReadonlyArray<fileType.FileType>;
 
 	/**
 	Supported MIME types.
 	*/
-	readonly mimeTypes: fileType.MimeType;
+	readonly mimeTypes: ReadonlyArray<fileType.MimeType>;
 
 	/**
 	Detect the file type of a readable stream.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -15,9 +15,9 @@ if (result !== undefined) {
 
 expectType<number>(fileType.minimumBytes);
 
-expectType<fileType.FileType>(fileType.extensions);
+expectType<ReadonlyArray<fileType.FileType>>(fileType.extensions);
 
-expectType<fileType.MimeType>(fileType.mimeTypes);
+expectType<ReadonlyArray<fileType.MimeType>>(fileType.mimeTypes);
 
 const readableStream = fs.createReadStream('file.png');
 const streamWithFileType = fileType.stream(readableStream);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -15,9 +15,9 @@ if (result !== undefined) {
 
 expectType<number>(fileType.minimumBytes);
 
-expectType<fileType.FileType[]>(fileType.extensions);
+expectType<ReadonlyArray<fileType.FileType>>(fileType.extensions);
 
-expectType<fileType.MimeType[]>(fileType.mimeTypes);
+expectType<ReadonlyArray<fileType.MimeType>>(fileType.mimeTypes);
 
 const readableStream = fs.createReadStream('file.png');
 const streamWithFileType = fileType.stream(readableStream);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -15,9 +15,9 @@ if (result !== undefined) {
 
 expectType<number>(fileType.minimumBytes);
 
-expectType<ReadonlyArray<fileType.FileType>>(fileType.extensions);
+expectType<fileType.FileType[]>(fileType.extensions);
 
-expectType<ReadonlyArray<fileType.MimeType>>(fileType.mimeTypes);
+expectType<fileType.MimeType[]>(fileType.mimeTypes);
 
 const readableStream = fs.createReadStream('file.png');
 const streamWithFileType = fileType.stream(readableStream);


### PR DESCRIPTION
Type definition for `extensions` and `mimeTypes` properties are wrong.

Considering they're a list of `T` (in this case, either `FileType` or `MimeType`), they should be defined as `ReadonlyArray<T>` instead of `T`