### PR TITLE
Stop execution after `fileType.stream` error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1051,7 +1051,7 @@ fileType.stream = readableStream => new Promise((resolve, reject) => {
 		try {
 			pass.fileType = fileType(chunk);
 		} catch (error) {
-			reject(error);
+			return reject(error);
 		}
 
 		readableStream.unshift(chunk);

--- a/index.js
+++ b/index.js
@@ -1051,7 +1051,8 @@ fileType.stream = readableStream => new Promise((resolve, reject) => {
 		try {
 			pass.fileType = fileType(chunk);
 		} catch (error) {
-			return reject(error);
+			reject(error);
+			return;
 		}
 
 		readableStream.unshift(chunk);


### PR DESCRIPTION
In function `stream()`: prevent `resolve()` is called after `reject()`, in case of an error caught in `fileType()`.

Related comment: https://github.com/sindresorhus/file-type/pull/261/files#r360335513


 
