### PR TITLE
Fix duplicate name using module instance & file-type result.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,39 +13,39 @@ $ npm install file-type
 
 ## Usage
 
-❗ Please be aware, the API changed, to support smarter and more specialized methods to determine the file type ❗
+❗️ Please be aware, the API changed, to support smarter and more specialized methods to determine the file type ❗️
+
 ##### Node.js
 
 Determine file type from a file:
 ```js
-const fileType = require('file-type');
+const FileType = require('file-type');
 
 (async () => {
-	const fileType = await fileType.fromFile('/home/borewit/Pictures/background.png');
+	const fileType = await FileType.fromFile('/home/borewit/Pictures/background.png');
 	// fileType = {ext: 'png', mime: 'image/png'}
 })();
 ```
 
 Determine file type from a Buffer, which may be a portion of the beginning of a file.
 ```js
-const fileType = require('file-type');
+const FileType = require('file-type');
 const readChunk = require('read-chunk');
 
 (async () => {
-	const buffer = readChunk.sync('unicorn.png', 0, fileType.minimumBytes);
-	const fileType = await fileType.fromBuffer(buffer);
-	// fileType = {ext: 'png', mime: 'image/png'}
+    const buffer = readChunk.sync('unicorn.png', 0, fileType.minimumBytes);
+    const fileType = await FileType.fromBuffer(buffer);
+    // fileType = {ext: 'png', mime: 'image/png'}
 })();
 ```
-
 Determine file type from a stream
 ```js
-const fileType = require('file-type');
+const FileType = require('file-type');
 const fs = require('fs');
 
 (async () => {
 	const stream = fs.createReadStream('/Users/adam/myFile.mp4');
-	const fileType = await fileType.fromStream(stream);
+	const fileType = await FileType.fromStream(stream);
 	// fileType = {ext: 'mp4', mime: 'image/mp4'}
 }
 )();
@@ -54,17 +54,17 @@ const fs = require('fs');
 Or from a remote location:
 
 ```js
-const fileType = require('file-type');
+const FileType = require('file-type');
 const http = require('http');
 
 const url = 'https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif';
 
 http.get(url, response => {
 	response.on('readable', () => {
-		const chunk = response.read(fileType.minimumBytes);
+		const chunk = response.read(FileType.minimumBytes);
 		response.destroy();
 
-		console.log(fileType.fromBuffer(chunk)); // ToDo change to stream
+		console.log(FileType.fromBuffer(chunk)); // ToDo change to stream
 		//=> {ext: 'gif', mime: 'image/gif'}
 	});
 });
@@ -82,7 +82,7 @@ const fileType = require('file-type');
 	const read = fs.createReadStream('encrypted.enc');
 	const decipher = crypto.createDecipheriv(alg, key, iv);
 
-	const fileTypeStream = await fileType.stream(stream.pipeline(read, decipher));
+	const fileTypeStream = await FileType.stream(stream.pipeline(read, decipher));
 
 	console.log(fileTypeStream.fileType);
 	//=> {ext: 'mov', mime: 'video/quicktime'}


### PR DESCRIPTION
Fix README:
* Use `FileType` for file-type module instance.
* Use `fileType` for function result.
