### PR TITLE
Update example `fromTokenizer()` to @tokenizer/http v0.5.0

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -294,10 +294,10 @@ declare namespace core {
 
 	(async () => {
 		const httpTokenizer = await makeTokenizer(audioTrackUrl);
-
 		const fileType = await FileType.fromTokenizer(httpTokenizer);
+
 		console.log(fileType);
-		// => {ext: 'mp3', mime: 'audio/mpeg'}
+		//=> {ext: 'mp3', mime: 'audio/mpeg'}
 	})();
 	```
 

--- a/core.d.ts
+++ b/core.d.ts
@@ -287,20 +287,17 @@ declare namespace core {
 	An example is [`@tokenizer/http`](https://github.com/Borewit/tokenizer-http), which requests data using [HTTP-range-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests). A difference with a conventional stream and the [*tokenizer*](https://github.com/Borewit/strtok3#tokenizer), is that it is able to *ignore* (seek, fast-forward) in the stream. For example, you may only need and read the first 6 bytes, and the last 128 bytes, which may be an advantage in case reading the entire file would take longer.
 
 	```
-	import {HttpTokenizer} = require('@tokenizer/http');
-	import FileType = require('file-type');
+	const {makeTokenizer} = require('@tokenizer/http');
+	const FileType = require('file-type');
 
 	const audioTrackUrl = 'https://test-audio.netlify.com/Various%20Artists%20-%202009%20-%20netBloc%20Vol%2024_%20tiuqottigeloot%20%5BMP3-V2%5D/01%20-%20Diablo%20Swing%20Orchestra%20-%20Heroines.mp3';
 
 	(async () => {
-		const httpTokenizer = HttpTokenizer.fromUrl(audioTrackUrl, {
-			avoidHeadRequests: true
-		});
+		const httpTokenizer = await makeTokenizer(audioTrackUrl);
 
-		await httpTokenizer.init();
-
-		console.log(await FileType.fromTokenizer(httpTokenizer));
-		//=> {ext: 'mp3', mime: 'audio/mpeg'}
+		const fileType = await FileType.fromTokenizer(httpTokenizer);
+		console.log(fileType);
+		// => {ext: 'mp3', mime: 'audio/mpeg'}
 	})();
 	```
 

--- a/core.d.ts
+++ b/core.d.ts
@@ -287,8 +287,8 @@ declare namespace core {
 	An example is [`@tokenizer/http`](https://github.com/Borewit/tokenizer-http), which requests data using [HTTP-range-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests). A difference with a conventional stream and the [*tokenizer*](https://github.com/Borewit/strtok3#tokenizer), is that it is able to *ignore* (seek, fast-forward) in the stream. For example, you may only need and read the first 6 bytes, and the last 128 bytes, which may be an advantage in case reading the entire file would take longer.
 
 	```
-	const {makeTokenizer} = require('@tokenizer/http');
-	const FileType = require('file-type');
+	import {makeTokenizer} = require('@tokenizer/http');
+	import FileType = require('file-type');
 
 	const audioTrackUrl = 'https://test-audio.netlify.com/Various%20Artists%20-%202009%20-%20netBloc%20Vol%2024_%20tiuqottigeloot%20%5BMP3-V2%5D/01%20-%20Diablo%20Swing%20Orchestra%20-%20Heroines.mp3';
 

--- a/readme.md
+++ b/readme.md
@@ -203,20 +203,17 @@ Or `undefined` when there is no match.
 An example is [`@tokenizer/http`](https://github.com/Borewit/tokenizer-http), which requests data using [HTTP-range-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests). A difference with a conventional stream and the [*tokenizer*](https://github.com/Borewit/strtok3#tokenizer), is that it can *ignore* (seek, fast-forward) in the stream. For example, you may only need and read the first 6 bytes, and the last 128 bytes, which may be an advantage in case reading the entire file would take longer.
 
 ```js
-const {HttpTokenizer} = require('@tokenizer/http');
+const {makeTokenizer} = require('@tokenizer/http');
 const FileType = require('file-type');
 
 const audioTrackUrl = 'https://test-audio.netlify.com/Various%20Artists%20-%202009%20-%20netBloc%20Vol%2024_%20tiuqottigeloot%20%5BMP3-V2%5D/01%20-%20Diablo%20Swing%20Orchestra%20-%20Heroines.mp3';
 
 (async () => {
-	const httpTokenizer = HttpTokenizer.fromUrl(audioTrackUrl, {
-		avoidHeadRequests: true
-	});
+	const httpTokenizer = await makeTokenizer(audioTrackUrl);
 
-	await httpTokenizer.init();
-
-	console.log(await FileType.fromTokenizer(httpTokenizer));
-	//=> {ext: 'mp3', mime: 'audio/mpeg'}
+	const fileType = await FileType.fromTokenizer(httpTokenizer);
+	console.log(fileType);
+	// => { ext: 'mp3', mime: 'audio/mpeg' }
 })();
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -210,10 +210,10 @@ const audioTrackUrl = 'https://test-audio.netlify.com/Various%20Artists%20-%2020
 
 (async () => {
 	const httpTokenizer = await makeTokenizer(audioTrackUrl);
-
 	const fileType = await FileType.fromTokenizer(httpTokenizer);
+
 	console.log(fileType);
-	// => { ext: 'mp3', mime: 'audio/mpeg' }
+	// => {ext: 'mp3', mime: 'audio/mpeg'}
 })();
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,7 @@ const audioTrackUrl = 'https://test-audio.netlify.com/Various%20Artists%20-%2020
 	const fileType = await FileType.fromTokenizer(httpTokenizer);
 
 	console.log(fileType);
-	// => {ext: 'mp3', mime: 'audio/mpeg'}
+	//=> {ext: 'mp3', mime: 'audio/mpeg'}
 })();
 ```
 


### PR DESCRIPTION
Update `fromTokenizer` example to [@tokenizer/http v0.5.0](https://github.com/Borewit/tokenizer-http/releases/tag/v0.5.0) API.

Fixes #287