### PR TITLE
Add debug test run script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 yarn.lock
-.idea

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"node": ">=10"
 	},
 	"scripts": {
+		"ava": "ava --serial --verbose",
 		"test": "xo && ava && tsd"
 	},
 	"files": [


### PR DESCRIPTION
I know ava tests can be executed with `npx ava`, however, I cannot run such a target from my IntelliJ IDEA debugger. I don't want to put in and remove that small line by hand. 

I also ignored the IntelliJ project files. Some will say, I should put those in my user settings. However sharing such projects files can vary per project. I don't think it will harm anyone, and can be read add a project policy not to include these files.