### PR TITLE
Fix TypeScript types in browser.d.ts

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -1,4 +1,9 @@
+/// <reference lib="dom"/>
 import * as core from './core';
+
+export type FileTypeResult = core.FileTypeResult;
+export type FileExtension = core.FileExtension;
+export type MimeType = core.MimeType;
 
 /**
 Determine file type from a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).

--- a/browser.d.ts
+++ b/browser.d.ts
@@ -17,7 +17,7 @@ const url = 'https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg';
 })();
 ```
 */
-export declare function fromStream(stream: ReadableStream): Promise<core.FileType>;
+export declare function fromStream(stream: ReadableStream): Promise<core.FileTypeResult>;
 
 /**
 Determine file type from a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
@@ -36,7 +36,7 @@ import FileType = require('file-type/browser');
 })();
 ```
 */
-export declare function fromeBlob(blob: Blob): Promise<core.FileType>;
+export declare function fromeBlob(blob: Blob): Promise<core.FileTypeResult>;
 
 export {
 	fromBuffer,


### PR DESCRIPTION
Sorry for multiple PRs.
I fixed an issue of the type definition.

Before PR:
![image](https://user-images.githubusercontent.com/10933561/71895284-ff377700-3193-11ea-8ed7-1e0e1ef4abc9.png)

After PR:
![image](https://user-images.githubusercontent.com/10933561/71895290-05c5ee80-3194-11ea-871a-2aff19991dd2.png)

---

I have a question. Is it better to add the following exports to browser.d.ts?

```ts
export type FileTypeResult = core.FileTypeResult;
export type FileExtension = core.FileExtension;
export type MimeType = core.MimeType;
```

---



If you're adding support for a new file type, please follow the below steps:

- **One PR per file type.**
- Add a fixture file named `fixture.<extension>` to the `fixture` directory.
- Add the file extension to the `extensions` array in `supported.js`.
- Add the file's MIME type to the `types` array in `supported.js`.
- Add the file type detection logic to the `index.js` file.
- Add the file extension to the `FileType` type in `index.d.ts`.
- Add the file's MIME type to the `MimeType` type in `index.d.ts`.
- Add the file extension to the `Supported file types` section in the readme, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```
- Add the file extension to the `keywords` array in the `package.json` file.
- Run `$ npm test` to ensure the tests pass.
- Open a pull request with a title like `Add support for Format`, for example, `Add support for PNG`.
- The pull request description should include a link to the official page of the file format or some other source. Also include a link to where you found the file type detection / magic bytes and the MIME type.
