### PR TITLE
Make stream() method, stream based, by using teeing

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
 		"readable-web-to-node-stream": "^2.0.0",
 		"strtok3": "^6.0.0",
 		"token-types": "^2.0.0",
-		"typedarray-to-buffer": "^3.1.5"
+		"typedarray-to-buffer": "^3.1.5",
+		"t-readable": "^0.1.0"
 	},
 	"xo": {
 		"envs": [


### PR DESCRIPTION
**Request for comments, NOT SUITABLE FOR MERGING**

With version [v13.0.0](https://github.com/sindresorhus/file-type/releases/tag/v13.0.0) we moved away from the ~4 kilobyte sample boundary, allowing, if required, deeper analysis of files, streams or Buffers.

Very handy to determine the file type, before passing it to the corresponding parser.

The [`stream()` method](https://github.com/sindresorhus/file-type#stream), which aims to take a [`Readable` stream](https://nodejs.org/api/stream.html#stream_class_stream_readable), resolves the _file-type_, and returns, a `Readable` delivering the same content as received plus the resolved _file-type_, is still (or may) from this ~4 kilobyte limitation. Actually it may get a larger sample (chunk), but this is more luck then wisdom.

This PR is using a [stream tee module](https://github.com/Borewit/t-readable), splitting a [`Readable` stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) into multiple [`Readable` streams](https://nodejs.org/api/stream.html#stream_class_stream_readable).

Handy isn't? One stream file for file type determination, one for the caller. Which probably would work great, if both streams would be consumed (read from) at the same time. Because we first read from the first copy of the stream, to an arbitrary point to determine the type, and only at that point we return the second copy.

Of-course it possible to cache all data read for determine the file type, and inject that in the returning stream. But that may cost an arbitrary amount of memory.

I thought is was worth sharing the issue and experience, even though I did not manage to crack the problem.