### PR TITLE
Keep supporting Node v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - '12'
   - '10'
+  - '8'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
Restore Node.js version 8 compatibility.

I think the minimum Node engine version is set unnecessary high. 