### PR TITLE
Prevent size related exceptions

### DIFF
--- a/core.js
+++ b/core.js
@@ -62,6 +62,10 @@ async function fromTokenizer(tokenizer) {
 	const check = (header, options) => _check(buffer, header, options);
 	const checkString = (header, options) => check(stringToBytes(header), options);
 
+	if (!tokenizer.fileInfo.size) {
+		tokenizer.fileInfo.size = Number.MAX_SAFE_INTEGER;
+	}
+
 	await tokenizer.peekBuffer(buffer, 0, bytesRead, tokenizer.position, true);
 
 	// -- 2-byte signatures --

--- a/core.js
+++ b/core.js
@@ -63,7 +63,7 @@ async function fromTokenizer(tokenizer) {
 	const checkString = (header, options) => check(stringToBytes(header), options);
 
 	if (!tokenizer.fileInfo.size) {
-		tokenizer.fileInfo.size = Number.MAX_SAFE_INTEGER;
+		tokenizer.fileInfo.size = Number.MAX_SAFE_INTEGER; // if file-size is unknown, keep reading until EOF
 	}
 
 	await tokenizer.peekBuffer(buffer, 0, bytesRead, tokenizer.position, true);

--- a/core.js
+++ b/core.js
@@ -62,8 +62,9 @@ async function fromTokenizer(tokenizer) {
 	const check = (header, options) => _check(buffer, header, options);
 	const checkString = (header, options) => check(stringToBytes(header), options);
 
+	// Keep reading until EOF if the file size is unknown.
 	if (!tokenizer.fileInfo.size) {
-		tokenizer.fileInfo.size = Number.MAX_SAFE_INTEGER; // if file-size is unknown, keep reading until EOF
+		tokenizer.fileInfo.size = Number.MAX_SAFE_INTEGER;
 	}
 
 	await tokenizer.peekBuffer(buffer, 0, bytesRead, tokenizer.position, true);

--- a/core.js
+++ b/core.js
@@ -62,7 +62,7 @@ async function fromTokenizer(tokenizer) {
 	const check = (header, options) => _check(buffer, header, options);
 	const checkString = (header, options) => check(stringToBytes(header), options);
 
-	await tokenizer.peekBuffer(buffer, 0, bytesRead);
+	await tokenizer.peekBuffer(buffer, 0, bytesRead, tokenizer.position, true);
 
 	// -- 2-byte signatures --
 

--- a/test.js
+++ b/test.js
@@ -447,3 +447,14 @@ test('validate the repo has all extensions and mimes in sync', t => {
 		}
 	}
 });
+
+test('odd file sizes', async t => {
+	const oddFileSizes = [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 255, 256, 257, 511, 512, 513];
+
+	for (const size of oddFileSizes) {
+		const buf = Buffer.alloc(size);
+		await t.notThrowsAsync(async () => {
+			await FileType.fromBuffer(buf);
+		}, `file size = ${size} bytes`);
+	}
+});

--- a/test.js
+++ b/test.js
@@ -452,9 +452,7 @@ test('odd file sizes', async t => {
 	const oddFileSizes = [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 255, 256, 257, 511, 512, 513];
 
 	for (const size of oddFileSizes) {
-		const buf = Buffer.alloc(size);
-		await t.notThrowsAsync(async () => {
-			await FileType.fromBuffer(buf);
-		}, `file size = ${size} bytes`);
+		const buffer = Buffer.alloc(size);
+		await t.notThrowsAsync(FileType.fromBuffer(buffer), `File size: ${size} bytes`);
 	}
 });


### PR DESCRIPTION
Prevent exceptions:
* Parsing very small "file" sizes, fixes #306
* Parse files with unknown "file" size, like a stream required to fix failing unit tests #291.