### PR TITLE
Update dependency strtok3 to v5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
 	},
 	"dependencies": {
 		"readable-web-to-node-stream": "^2.0.0",
-		"strtok3": "^5.0.1",
+		"strtok3": "^5.0.2",
 		"token-types": "^2.0.0",
 		"typedarray-to-buffer": "^3.1.5"
 	},


### PR DESCRIPTION
Update [strtok3](https://github.com/Borewit/strtok3) to[ v5.0.2](https://github.com/Borewit/strtok3/releases/tag/v5.0.2), update [@tokenizer/token](https://github.com/Borewit/tokenizer-token) from 0.1.0 to [0.1.1](https://github.com/Borewit/tokenizer-token/releases/tag/v0.1.1),  fixing a [missing license](https://github.com/Borewit/tokenizer-token/issues/1)