### PR TITLE
Ensure `.fromBuffer()` always returns a Promise

### DIFF
--- a/core.js
+++ b/core.js
@@ -20,7 +20,7 @@ async function fromStream(stream) {
 	}
 }
 
-function fromBuffer(input) {
+async function fromBuffer(input) {
 	if (!(input instanceof Uint8Array || input instanceof ArrayBuffer || Buffer.isBuffer(input))) {
 		throw new TypeError(`Expected the \`input\` argument to be of type \`Uint8Array\` or \`Buffer\` or \`ArrayBuffer\`, got \`${typeof input}\``);
 	}

--- a/test.js
+++ b/test.js
@@ -292,21 +292,14 @@ test('FileType.mimeTypes.has', t => {
 });
 
 test('validate the input argument type', async t => {
-	await t.throwsAsync(async () => {
-		await FileType.fromBuffer('x');
-	}, /Expected the `input` argument to be of type `Uint8Array`/);
+	await t.throwsAsync(FileType.fromBuffer('x'),
+		/Expected the `input` argument to be of type `Uint8Array`/);
 
-	await t.notThrowsAsync(async () => {
-		await FileType.fromBuffer(Buffer.from('x'));
-	});
+	await t.notThrowsAsync(FileType.fromBuffer(Buffer.from('x')));
 
-	await t.notThrowsAsync(async () => {
-		await FileType.fromBuffer(new Uint8Array());
-	});
+	await t.notThrowsAsync(FileType.fromBuffer(new Uint8Array()));
 
-	await t.notThrowsAsync(async () => {
-		await FileType.fromBuffer(new ArrayBuffer());
-	});
+	await t.notThrowsAsync(FileType.fromBuffer(new ArrayBuffer()));
 });
 
 test('validate the repo has all extensions and mimes in sync', t => {


### PR DESCRIPTION
Fixes #309.

Changes:
* Ensure [`FileType.fromBuffer()`](https://github.com/sindresorhus/file-type#filetypefrombufferbuffer) returns a Promise.
* Simplify async unit tests.

