### PR TITLE
Fix issues in unit tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -182,24 +182,26 @@ async function testFromBuffer(t, ext, name) {
 	await checkBufferLike(t, ext, chunk.buffer);
 }
 
-const testFalsePositive = async (t, ext, name) => {
+async function testFalsePositive(t, ext, name) {
 	const file = path.join(__dirname, 'fixture', `${name}.${ext}`);
 	const chunk = readChunk.sync(file, 0, 4 + 4096);
 
 	t.is(await FileType.fromBuffer(chunk), undefined);
 	t.is(await FileType.fromBuffer(new Uint8Array(chunk)), undefined);
 	t.is(await FileType.fromBuffer(chunk.buffer), undefined);
-};
+}
 
-const testFileFromStream = async (t, ext, name) => {
-	const file = path.join(__dirname, 'fixture', `${(name || 'fixture')}.${ext}`);
-	const readableStream = await FileType.stream(fs.createReadStream(file));
+async function testFileFromStream(t, ext, name) {
+	const filename = `${(name || 'fixture')}.${ext}`;
+	const file = path.join(__dirname, 'fixture', filename);
+	const fileType = await FileType.fromStream(fs.createReadStream(file));
 
-	const _fileType = await FileType.fromBuffer(readChunk.sync(file, 0, FileType.minimumBytes));
-	t.deepEqual(readableStream.fileType, _fileType);
-};
+	t.truthy(fileType, `identify ${filename}`);
+	t.is(fileType.ext, ext, 'fileType.ext');
+	t.is(typeof fileType.mime, 'string', 'fileType.mime');
+}
 
-const testStream = async (t, ext, name) => {
+async function testStream(t, ext, name) {
 	const fixtureName = `${(name || 'fixture')}.${ext}`;
 	const file = path.join(__dirname, 'fixture', fixtureName);
 
@@ -225,7 +227,7 @@ const testStream = async (t, ext, name) => {
 	const [bufferA, bufferB] = await Promise.all([loadEntireFile(readableStream), loadEntireFile(fileStream)]);
 
 	t.true(bufferA.equals(bufferB));
-};
+}
 
 let i = 0;
 for (const type of types) {


### PR DESCRIPTION
1. `testFileFromStream()` actually testing `FileType.fromStream()` :flushed:
2. Fixed issues in `core.js`, due to unknown file length, to make unit test passing:
   - level-2 parser for `.zip`
   - level-2 parser for `.mp3`
3. Let `testFileFromStream()` test independent instead comparing result with `fromBuffer`
3. Consistency declaring test functions: replace `const testX = () => {}` with `function testX() {}`