### PR TITLE
Fix end-of-stream exception in PNG level 2 parser

### DIFF
--- a/core.js
+++ b/core.js
@@ -57,6 +57,16 @@ function _check(buffer, headers, options) {
 }
 
 async function fromTokenizer(tokenizer) {
+	try {
+		return _fromTokenizer(tokenizer);
+	} catch (error) {
+		if (!(error instanceof strtok3.EndOfStreamError)) {
+			throw error;
+		}
+	}
+}
+
+async function _fromTokenizer(tokenizer) {
 	let buffer = Buffer.alloc(minimumBytes);
 	const bytesRead = 12;
 	const check = (header, options) => _check(buffer, header, options);


### PR DESCRIPTION
Fixes #313
Catch end-of-stream exceptions in `fromTokenizer` and return undefined (could not determine _file type_)
