### PR TITLE
Deprecate minimumBytes

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -45,7 +45,6 @@ export declare function fromBlob(blob: Blob): Promise<core.FileTypeResult | unde
 
 export {
 	fromBuffer,
-	minimumBytes,
 	extensions,
 	mimeTypes
 } from './core';

--- a/core.d.ts
+++ b/core.d.ts
@@ -315,11 +315,6 @@ declare namespace core {
 	function fromTokenizer(tokenizer: ITokenizer): Promise<core.FileTypeResult | undefined>;
 
 	/**
-	Deprecated: The minimum amount of bytes needed to detect a file type. Currently, it's 4100 bytes, but it can change, so don't hard-code it.
-	*/
-	const minimumBytes: number;
-
-	/**
 	Supported file extensions.
 	*/
 	const extensions: readonly core.FileExtension[];

--- a/core.js
+++ b/core.js
@@ -1240,7 +1240,7 @@ const stream = readableStream => new Promise((resolve, reject) => {
 	readableStream.on('error', reject);
 	readableStream.once('readable', async () => {
 		const pass = new stream.PassThrough();
-		const chunk = readableStream.read(fileType.minimumBytes) || readableStream.read();
+		const chunk = readableStream.read(minimumBytes) || readableStream.read();
 		try {
 			const fileType = await fromBuffer(chunk);
 			pass.fileType = fileType;
@@ -1263,8 +1263,7 @@ const fileType = {
 	fromStream,
 	fromTokenizer,
 	fromBuffer,
-	stream,
-	minimumBytes: 4100
+	stream
 };
 
 Object.defineProperty(fileType, 'extensions', {

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,6 @@ export function fromFile(path: string): Promise<core.FileTypeResult | undefined>
 export {
 	fromBuffer,
 	fromStream,
-	minimumBytes,
 	extensions,
 	mimeTypes,
 	stream

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -39,12 +39,9 @@ expectType<Promise<FileTypeResult | undefined>>(FileType.fromBuffer(new ArrayBuf
 	}
 })();
 
-expectType<number>(FileType.minimumBytes);
-
 expectType<readonly FileType.FileExtension[]>(FileType.extensions);
 
 expectType<readonly FileType.MimeType[]>(FileType.mimeTypes);
-
 
 const readableStream = fs.createReadStream('file.png');
 const streamWithFileType = FileType.stream(readableStream);

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ const FileType = require('file-type');
 const readChunk = require('read-chunk');
 
 (async () => {
-	const buffer = readChunk.sync('Unicorn.png', 0, fileType.minimumBytes);
+	const buffer = readChunk.sync('Unicorn.png', 0, 4100);
 
 	console.log(await FileType.fromBuffer(buffer));
 	//=> {ext: 'png', mime: 'image/png'}
@@ -236,12 +236,6 @@ Returns a `Promise` which resolves to the original readable stream argument, but
 Type: [`stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
 
 The input stream.
-
-### FileType.minimumBytes
-
-Type: `number`
-
-The minimum amount of bytes needed to detect a file type. Currently, it's 4100 bytes, but it can change, so don't hardcode it.
 
 ### FileType.extensions
 


### PR DESCRIPTION
`FileType.minimumBytes` became obsolete, now we read beyond this 4k boundary. It is still possible to to use a sample of the first portion of the file. 

To ensure the best file identification, the entire file should be provided. Therefor it is highly recommended to use the `parseFile()`, which efficiently reads those, and only those, parts of the files, required for the file identification. 

Related: #248