### PR TITLE
Prevent throwing error in `.stream()` on empty stream

### DIFF
--- a/core.js
+++ b/core.js
@@ -1284,7 +1284,7 @@ const stream = readableStream => new Promise((resolve, reject) => {
 	readableStream.on('error', reject);
 	readableStream.once('readable', async () => {
 		const pass = new stream.PassThrough();
-		const chunk = readableStream.read(minimumBytes) || readableStream.read();
+		const chunk = readableStream.read(minimumBytes) || readableStream.read() || Buffer.alloc(0);
 		try {
 			const fileType = await fromBuffer(chunk);
 			pass.fileType = fileType;

--- a/test.js
+++ b/test.js
@@ -274,10 +274,8 @@ for (const type of types) {
 }
 
 test('.stream() method - empty stream', async t => {
-	await t.throwsAsync(
-		FileType.stream(readableNoopStream()),
-		/Expected the `input` argument to be of type `Uint8Array` /
-	);
+	const fileType = await FileType.stream(readableNoopStream());
+	t.true(fileType.fileType === undefined);
 });
 
 test('.stream() method - error event', async t => {

--- a/test.js
+++ b/test.js
@@ -275,7 +275,7 @@ for (const type of types) {
 
 test('.stream() method - empty stream', async t => {
 	const fileType = await FileType.stream(readableNoopStream());
-	t.true(fileType.fileType === undefined);
+	t.is(fileType.fileType, undefined);
 });
 
 test('.stream() method - error event', async t => {


### PR DESCRIPTION
Prevent throwing error in [`stream()`](https://github.com/sindresorhus/file-type#filetypestreamreadablestream), on empty stream.

Fixes #269.
