### PR TITLE
Fix missing `fromTokenizer` type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ export function fromFile(path: string): Promise<core.FileTypeResult | undefined>
 export {
 	fromBuffer,
 	fromStream,
+	fromTokenizer,
 	extensions,
 	mimeTypes,
 	stream


### PR DESCRIPTION
Currently `fromTokenizer` function only can be accessed by importing `file-type/core` due to missing type definition in type index.
This PR adds missing (re-exporting) `fromTokenizer` type definition.

----

BTW I don't want to leave off-topic message but I really LOVE that face-lifted API. Previously i manually peeked file in AWS S3 by sending ranged request. It added more complexity for inspecting file type. but now, we can just use handy tokenizers like `@tokenizers/s3` package!

@sindresorhus and @Borewit, Thanks for maintaining this project and Kudos for your work ❤️ 