### PR TITLE
Fix error when using `FileType.fromStream()` on small files

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
 	},
 	"dependencies": {
 		"readable-web-to-node-stream": "^2.0.0",
-		"strtok3": "^6.0.2",
+		"strtok3": "^6.0.3",
 		"token-types": "^2.0.0",
 		"typedarray-to-buffer": "^3.1.5"
 	},

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
 	},
 	"dependencies": {
 		"readable-web-to-node-stream": "^2.0.0",
-		"strtok3": "^6.0.0",
+		"strtok3": "^6.0.2",
 		"token-types": "^2.0.0",
 		"typedarray-to-buffer": "^3.1.5"
 	},

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import {Readable} from 'stream';
+import stream from 'stream';
 import test from 'ava';
 import {readableNoopStream} from 'noop-stream';
 import FileType from '.';
@@ -286,7 +286,7 @@ test('.stream() method - empty stream', async t => {
 
 test('.stream() method - short stream', async t => {
 	const bufferA = Buffer.from([0, 1, 0, 1]);
-	class MyStream extends Readable {
+	class MyStream extends stream.Readable {
 		_read() {
 			this.push(bufferA);
 			this.push(null);
@@ -306,7 +306,7 @@ test('.stream() method - short stream', async t => {
 test('.stream() method - error event', async t => {
 	const errorMessage = 'Fixture';
 
-	const readableStream = new Readable({
+	const readableStream = new stream.Readable({
 		read() {
 			process.nextTick(() => {
 				this.emit('error', new Error(errorMessage));
@@ -484,7 +484,7 @@ test('validate the repo has all extensions and mimes in sync', t => {
 	}
 });
 
-class BufferedStream extends Readable {
+class BufferedStream extends stream.Readable {
 	constructor(buffer) {
 		super();
 		this.push(buffer);

--- a/test.js
+++ b/test.js
@@ -491,8 +491,7 @@ class BufferedStream extends stream.Readable {
 		this.push(null);
 	}
 
-	_read() {
-	}
+	_read() {}
 }
 
 test('odd file sizes', async t => {


### PR DESCRIPTION
- Update [strtok3](https://github.com/Borewit/strtok) to [6.0.1](https://github.com/Borewit/strtok3/releases/tag/v6.0.1), fixes #341
- Add unit test revealing issue #341: test parsing short files in combination with [`FileType.fromStream`](https://github.com/sindresorhus/file-type#filetypefromstreamstream)

Note that the actual fix is implemented via a patch release in [strtok3 version 6.0.1](https://github.com/Borewit/strtok3/releases/tag/v6.0.1).