### PR TITLE
Replace `uint8ArrayUtf8ByteString()` with `Buffer.toString()`.

### DIFF
--- a/core.js
+++ b/core.js
@@ -463,7 +463,7 @@ async function _fromTokenizer(tokenizer) {
 	) {
 		// They all can have MIME `video/mp4` except `application/mp4` special-case which is hard to detect.
 		// For some cases, we're specific, everything else falls to `video/mp4` with `mp4` extension.
-		const brandMajor = buffer.toString('utf8', 8, 12).replace('\0', ' ').trim();
+		const brandMajor = buffer.toString('binary', 8, 12).replace('\0', ' ').trim();
 		switch (brandMajor) {
 			case 'avif':
 				return {ext: 'avif', mime: 'image/avif'};

--- a/core.js
+++ b/core.js
@@ -4,8 +4,7 @@ const strtok3 = require('strtok3/lib/core');
 const {
 	stringToBytes,
 	tarHeaderChecksumMatches,
-	uint32SyncSafeToken,
-	uint8ArrayUtf8ByteString
+	uint32SyncSafeToken
 } = require('./util');
 const supported = require('./supported');
 
@@ -464,7 +463,7 @@ async function _fromTokenizer(tokenizer) {
 	) {
 		// They all can have MIME `video/mp4` except `application/mp4` special-case which is hard to detect.
 		// For some cases, we're specific, everything else falls to `video/mp4` with `mp4` extension.
-		const brandMajor = uint8ArrayUtf8ByteString(buffer, 8, 12).replace('\0', ' ').trim();
+		const brandMajor = buffer.toString('utf8', 8, 12).replace('\0', ' ').trim();
 		switch (brandMajor) {
 			case 'avif':
 				return {ext: 'avif', mime: 'image/avif'};

--- a/util.js
+++ b/util.js
@@ -2,10 +2,6 @@
 
 exports.stringToBytes = string => [...string].map(character => character.charCodeAt(0));
 
-const uint8ArrayUtf8ByteString = (array, start, end) => {
-	return String.fromCharCode(...array.slice(start, end));
-};
-
 exports.tarHeaderChecksumMatches = buffer => { // Does not check if checksum field characters are valid
 	if (buffer.length < 512) { // `tar` header size, cannot compute checksum without it
 		return false;
@@ -30,7 +26,7 @@ exports.tarHeaderChecksumMatches = buffer => { // Does not check if checksum fie
 		signedBitSum += byte & MASK_8TH_BIT; // Add signed bit to signed bit sum
 	}
 
-	const readSum = parseInt(uint8ArrayUtf8ByteString(buffer, 148, 154), 8); // Read sum in header
+	const readSum = parseInt(buffer.toString('binary', 148, 154), 8); // Read sum in header
 
 	// Some implementations compute checksum incorrectly using signed bytes
 	return (
@@ -41,8 +37,6 @@ exports.tarHeaderChecksumMatches = buffer => { // Does not check if checksum fie
 		readSum === (sum - (signedBitSum << 1))
 	);
 };
-
-exports.uint8ArrayUtf8ByteString = uint8ArrayUtf8ByteString;
 
 /**
 ID3 UINT32 sync-safe tokenizer token.

--- a/util.js
+++ b/util.js
@@ -26,7 +26,7 @@ exports.tarHeaderChecksumMatches = buffer => { // Does not check if checksum fie
 		signedBitSum += byte & MASK_8TH_BIT; // Add signed bit to signed bit sum
 	}
 
-	const readSum = parseInt(buffer.toString('binary', 148, 154), 8); // Read sum in header
+	const readSum = parseInt(buffer.toString('ascii', 148, 154), 8); // Read sum in header
 
 	// Some implementations compute checksum incorrectly using signed bytes
 	return (


### PR DESCRIPTION
Working on #352, I thought we could get rid of  `uint8ArrayUtf8ByteString()` and rely on Node Buffer string conversions instead.

This PR replaces  `uint8ArrayUtf8ByteString()` with [`Buffer.toString()`](https://nodejs.org/api/buffer.html#buffer_buf_tostring_encoding_start_end).

Fine-tuned the decoding of:
* TAR header `chksum` to [ASCII](https://en.wikipedia.org/wiki/ASCII)
* MPEG-4 brand major identifier to [ISO 8859-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1)
