### PR TITLE
Simplify `tar` checksum calculation

### DIFF
--- a/util.js
+++ b/util.js
@@ -3,11 +3,12 @@
 exports.stringToBytes = string => [...string].map(character => character.charCodeAt(0));
 
 /**
- * Return true if the tar checksum is valid
- * @param {Buffer} buffer holding tar header [offset ... offset + 512]
- * @param {number} off TAR header offset
- * @returns {boolean} rue if the tar checksum is valid, otherwise false
- */
+Checks whether the TAR checksum is valid.
+
+@param {Buffer} buffer - The TAR header `[offset ... offset + 512]`.
+@param {number} offset - TAR header offset.
+@returns {boolean} `true` if the TAR checksum is valid, otherwise `false`.
+*/
 exports.tarHeaderChecksumMatches = (buffer, off) => {
 	off = off ? off : 0;
 

--- a/util.js
+++ b/util.js
@@ -9,9 +9,7 @@ Checks whether the TAR checksum is valid.
 @param {number} offset - TAR header offset.
 @returns {boolean} `true` if the TAR checksum is valid, otherwise `false`.
 */
-exports.tarHeaderChecksumMatches = (buffer, off) => {
-	off = off ? off : 0;
-
+exports.tarHeaderChecksumMatches = (buffer, offset = 0) => {
 	const readSum = parseInt(buffer.toString('utf8', 148, 154).replace(/\0.*$/, '').trim(), 8); // Read sum in header
 	if (isNaN(readSum)) {
 		return false;
@@ -19,11 +17,11 @@ exports.tarHeaderChecksumMatches = (buffer, off) => {
 
 	let sum = 8 * 0x20; // Initialize signed bit sum
 
-	for (let i = off; i < off + 148; i++) {
+	for (let i = offset; i < offset + 148; i++) {
 		sum += buffer[i];
 	}
 
-	for (let i = off + 156; i < off + 512; i++) {
+	for (let i = offset + 156; i < offset + 512; i++) {
 		sum += buffer[i];
 	}
 

--- a/util.js
+++ b/util.js
@@ -2,43 +2,32 @@
 
 exports.stringToBytes = string => [...string].map(character => character.charCodeAt(0));
 
-exports.tarHeaderChecksumMatches = buffer => { // Does not check if checksum field characters are valid
-	if (buffer.length < 512) { // `tar` header size, cannot compute checksum without it
-		return false;
-	}
+/**
+ * Return true if the tar checksum is valid
+ * @param {Buffer} buffer holding tar header [offset ... offset + 512]
+ * @param {number} off TAR header offset
+ * @returns {boolean} rue if the tar checksum is valid, otherwise false
+ */
+exports.tarHeaderChecksumMatches = (buffer, off) => {
+	off = off ? off : 0;
 
 	const readSum = parseInt(buffer.toString('utf8', 148, 154).replace(/\0.*$/, '').trim(), 8); // Read sum in header
 	if (isNaN(readSum)) {
 		return false;
 	}
 
-	const MASK_8TH_BIT = 0x80;
+	let sum = 8 * 0x20; // Initialize signed bit sum
 
-	let sum = 256; // Initialize sum, with 256 as sum of 8 spaces in checksum field
-	let signedBitSum = 0; // Initialize signed bit sum
-
-	for (let i = 0; i < 148; i++) {
-		const byte = buffer[i];
-		sum += byte;
-		signedBitSum += byte & MASK_8TH_BIT; // Add signed bit to signed bit sum
+	for (let i = off; i < off + 148; i++) {
+		sum += buffer[i];
 	}
 
-	// Skip checksum field
-
-	for (let i = 156; i < 512; i++) {
-		const byte = buffer[i];
-		sum += byte;
-		signedBitSum += byte & MASK_8TH_BIT; // Add signed bit to signed bit sum
+	for (let i = off + 156; i < off + 512; i++) {
+		sum += buffer[i];
 	}
 
 	// Some implementations compute checksum incorrectly using signed bytes
-	return (
-		// Checksum in header equals the sum we calculated
-		readSum === sum ||
-
-		// Checksum in header equals sum we calculated plus signed-to-unsigned delta
-		readSum === (sum - (signedBitSum << 1))
-	);
+	return readSum === sum;
 };
 
 /**

--- a/util.js
+++ b/util.js
@@ -25,7 +25,6 @@ exports.tarHeaderChecksumMatches = (buffer, offset = 0) => {
 		sum += buffer[i];
 	}
 
-	// Some implementations compute checksum incorrectly using signed bytes
 	return readSum === sum;
 };
 


### PR DESCRIPTION
Simplify function `util.tarHeaderChecksumMatches`:
- Decoding based on [node-tar](https://github.com/npm/node-tar/blob/8b605d7def4cb15370b573ea45a1831a2fe1cd9d/lib/header.js#L97) (note that they do not include the `signedBitSum`)
- Add comments
- Preserve (TAR header) offset as an optional second parameter

This PR should not change any behavior.

Related to #385