### PR TITLE
Add magic to package.json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"mime",
 		"file",
 		"type",
+		"magic",
 		"archive",
 		"image",
 		"img",

--- a/test.js
+++ b/test.js
@@ -370,6 +370,7 @@ test('validate the repo has all extensions and mimes in sync', t => {
 			'mime',
 			'file',
 			'type',
+			'magic',
 			'archive',
 			'image',
 			'img',


### PR DESCRIPTION
Because it's a "magic number" and the unix lib is called "libmagic"

documentation change.