### PR TITLE
Add the ability to register third-party extensions

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -370,7 +370,7 @@ declare namespace core {
 	*/
 	function stream(readableStream: ReadableStream): Promise<core.ReadableStreamWithFileType>
 
-	type Detection = (tokenizer: ITokenizer, fileType? : core.FileTypeResult) => Promise<core.FileTypeResult | undefined>;
+	type Detection = (tokenizer: ITokenizer, fileType?: core.FileTypeResult) => Promise<core.FileTypeResult | undefined>;
 
 	function addDetection(detection: Detection): void;
 }

--- a/core.d.ts
+++ b/core.d.ts
@@ -369,6 +369,10 @@ declare namespace core {
 	```
 	*/
 	function stream(readableStream: ReadableStream): Promise<core.ReadableStreamWithFileType>
+
+	type Detection = (tokenizer: ITokenizer, fileType? : core.FileTypeResult) => Promise<core.FileTypeResult | undefined>;
+
+	function addDetection(detection: Detection): void;
 }
 
 export = core;

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,5 +23,7 @@ export {
 	fromTokenizer,
 	extensions,
 	mimeTypes,
-	stream
+	stream,
+	Detection,
+	addDetection
 } from './core';

--- a/readme.md
+++ b/readme.md
@@ -270,12 +270,13 @@ Returns a set of supported MIME types.
 
 ### FileType.addDetection(detection)
 
-Register a detection function. This function fill be called after the file-type, and other detections completed.
-the `detection(tokenizer, fileType)` method has two arguments:
-* [tokenizer](https://github.com/Borewit/strtok3#tokenizer)
-* `fileType`, which is `undefined` or the return value of a detected file type.
+Register a detection function. This function will be called after `file-type` and other detections complete.
 
-If the detector returns `undefined` the tokenizer.position should be 0. That allows other detectors to parse the file. 
+The `detection(tokenizer, fileType)` method has two arguments:
+- [tokenizer](https://github.com/Borewit/strtok3#tokenizer)
+- `fileType`, which is `undefined` or the return value of a detected file type.
+
+If the detector returns `undefined`, the `tokenizer.position` should be 0. That allows other detectors to parse the file. 
 
 ## Supported file types
 

--- a/readme.md
+++ b/readme.md
@@ -268,6 +268,15 @@ Returns a set of supported file extensions.
 
 Returns a set of supported MIME types.
 
+### FileType.addDetection(detection)
+
+Register a detection function. This function fill be called after the file-type, and other detections completed.
+the `detection(tokenizer, fileType)` method has two arguments:
+* [tokenizer](https://github.com/Borewit/strtok3#tokenizer)
+* `fileType`, which is `undefined` or the return value of a detected file type.
+
+If the detector returns `undefined` the tokenizer.position should be 0. That allows other detectors to parse the file. 
+
 ## Supported file types
 
 - [`jpg`](https://en.wikipedia.org/wiki/JPEG)


### PR DESCRIPTION
### FileType.addDetection(detection)

Register a detection function. This function fill be called after the file-type, and other detections completed.
the `detection(tokenizer, fileType)` method has two arguments:
* [tokenizer](https://github.com/Borewit/strtok3#tokenizer)
* `fileType`, which is `undefined` or the return value of a detected file type.

Resolves #340.

Issues:
- Not possible to overrule existing file-type detection