### PR TITLE
Add support for ASCII STL

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -134,7 +134,8 @@ declare namespace core {
 		| 'eps'
 		| 'lzh'
 		| 'pgp'
-		| 'asar';
+		| 'asar'
+		| 'stl';
 
 	type MimeType =
 		| 'image/jpeg'
@@ -262,7 +263,8 @@ declare namespace core {
 		| 'image/avif'
 		| 'application/x-lzh-compressed'
 		| 'application/pgp-encrypted'
-		| 'application/x-asar';
+		| 'application/x-asar'
+		| 'model/stl';
 
 	interface FileTypeResult {
 		/**

--- a/core.js
+++ b/core.js
@@ -920,6 +920,13 @@ async function _fromTokenizer(tokenizer) {
 		};
 	}
 
+	if (checkString('solid ')) {
+		return {
+			ext: 'stl',
+			mime: 'model/stl'
+		};
+	}
+
 	// -- 7-byte signatures --
 
 	if (checkString('BLENDER')) {

--- a/fixture/fixture.stl
+++ b/fixture/fixture.stl
@@ -1,0 +1,23 @@
+solid SQUARE
+  facet normal  0.0   0.0  1.0    
+    outer loop
+      vertex    1.0   0.0   0.0    
+      vertex    0.5   0.5   0.0    
+      vertex    0.0   0.0   0.0    
+    endloop
+  endfacet
+  facet normal  0.0   0.0  1.0    
+    outer loop
+      vertex    0.0   0.0   0.0 
+      vertex    0.5   0.5   0.0    
+      vertex    0.0   1.0   0.0    
+    endloop
+  endfacet
+  facet normal  0.0   0.0   1.0    
+    outer loop
+      vertex    1.0   0.0   0.0
+      vertex    1.0   1.0   0.0
+      vertex    0.0   1.0   0.0
+    endloop
+  endfacet
+endsolid SQUARE

--- a/package.json
+++ b/package.json
@@ -178,7 +178,8 @@
 		"eps",
 		"lzh",
 		"pgp",
-		"asar"
+		"asar",
+		"stl"
 	],
 	"devDependencies": {
 		"@types/node": "^13.1.4",

--- a/readme.md
+++ b/readme.md
@@ -403,6 +403,7 @@ Returns a set of supported MIME types.
 - [`lzh`](https://en.wikipedia.org/wiki/LHA_(file_format)) - LZH archive
 - [`pgp`](https://en.wikipedia.org/wiki/Pretty_Good_Privacy) - Pretty Good Privacy
 - [`asar`](https://github.com/electron/asar#format) - Archive format primarily used to enclose Electron applications
+- [`stl`](https://en.wikipedia.org/wiki/STL_(file_format)) - Standard Tesselated Geometry File Format (ASCII only)
 
 *Pull requests are welcome for additional commonly used file types.*
 

--- a/supported.js
+++ b/supported.js
@@ -132,7 +132,8 @@ module.exports = {
 		'eps',
 		'lzh',
 		'pgp',
-		'asar'
+		'asar',
+		'stl'
 	],
 	mimeTypes: [
 		'image/jpeg',
@@ -260,6 +261,7 @@ module.exports = {
 		'image/avif',
 		'application/x-lzh-compressed',
 		'application/pgp-encrypted',
-		'application/x-asar'
+		'application/x-asar',
+		'model/stl'
 	]
 };


### PR DESCRIPTION
Add support for [ASCII STL](https://en.wikipedia.org/wiki/STL_%28file_format%29#ASCII_STL) files, as requested in #401 

Detects the first 6 bytes of the line `solid name` (where `name` is optional).

The fixture file is a 2d square.

Binary STL files are more common, but they do no contain any detectable header pattern.

---

If you're adding support for a new file type, please follow the below steps:

- [x] **One PR per file type.**
- [x] Add a fixture file named `fixture.<extension>` to the `fixture` directory.
- [x] Add the file extension to the `extensions` array in `supported.js`.
- [x] Add the file's MIME type to the `types` array in `supported.js`.
- [x] Add the file type detection logic to the `index.js` file.
- [x] Add the file extension to the `FileType` type in `core.d.ts`.
- [x] Add the file's MIME type to the `MimeType` type in `core.d.ts`.
- [x] Add the file extension to the `Supported file types` section in the readme, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```
- [x] Add the file extension to the `keywords` array in the `package.json` file.
- [x] Run `$ npm test` to ensure the tests pass.
- [x] Open a pull request with a title like `Add support for Format`, for example, `Add support for PNG`.
- [x] The pull request description should include a link to the official page of the file format or some other source. Also include a link to where you found the file type detection / magic bytes and the MIME type.
