### PR TITLE
Fix Webpack 5 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
 		"xo": "^0.25.3"
 	},
 	"dependencies": {
-		"readable-web-to-node-stream": "^2.0.0",
+		"readable-web-to-node-stream": "^3.0.0",
 		"strtok3": "^6.0.3",
 		"token-types": "^2.0.0",
 		"typedarray-to-buffer": "^3.1.5"


### PR DESCRIPTION
Fix #408.

Update [readable-web-to-node-stream](https://github.com/Borewit/readable-web-to-node-stream) (browser dependency) to [version 3](https://github.com/Borewit/readable-web-to-node-stream/releases/tag/v3.0.0), which includes a dependency to Node.js core shim stream dependency.
