### PR TITLE
Document `stream()` detection limitation

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -356,9 +356,20 @@ declare namespace core {
 	const mimeTypes: Set<core.MimeType>;
 
 	/**
+	 * Stream options.
+	 */
+	interface IStreamOptions {
+		/**
+		 *  Sample size in bytes.
+		 */
+		readonly sampleSize?: number
+	}
+
+	/**
 	Detect the file type of a readable stream.
 
 	@param readableStream - A [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) containing a file to examine.
+	@param options - Options
 	@returns A `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `FileType.fromFile()`.
 
 	@example
@@ -370,7 +381,7 @@ declare namespace core {
 	(async () => {
 		const read = fs.createReadStream('encrypted.enc');
 		const decipher = crypto.createDecipheriv(alg, key, iv);
-		const stream = await fileType.stream(read.pipe(decipher));
+		const stream = await fileType.stream(read.pipe(decipher), {sampleSize: 1024});
 
 		console.log(stream.fileType);
 		//=> {ext: 'mov', mime: 'video/quicktime'}
@@ -380,7 +391,7 @@ declare namespace core {
 	})();
 	```
 	*/
-	function stream(readableStream: ReadableStream): Promise<core.ReadableStreamWithFileType>
+	function stream(readableStream: ReadableStream, options?: IStreamOptions): Promise<core.ReadableStreamWithFileType>
 }
 
 export = core;

--- a/core.d.ts
+++ b/core.d.ts
@@ -356,9 +356,9 @@ declare namespace core {
 	const mimeTypes: Set<core.MimeType>;
 
 	/**
-	 * Stream options.
+	 * Option object, used by `stream()`.
 	 */
-	interface IStreamOptions {
+	interface StreamOptions {
 		/**
 		 *  Sample size in bytes.
 		 */
@@ -366,32 +366,36 @@ declare namespace core {
 	}
 
 	/**
-	Detect the file type of a readable stream.
+	Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `FileType.fromFile()`.
+
+	This method can be handy to put in between a stream, but it comes with a price.
+	Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample, to determine the file type.
+	The sample size impacts the file detection resolution.
+	A smaller sample size will result in lower probability of the best file type detection.
+
+	 *Note:* This method is only available using Node.js.
 
 	@param readableStream - A [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) containing a file to examine.
-	@param options - Options
+	@param options - Option object
 	@returns A `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `FileType.fromFile()`.
 
 	@example
-	```
-	import * as fs from 'fs';
-	import * as crypto from 'crypto';
-	import fileType = require('file-type');
+	```js
+	const got = require('got');
+	const FileType = require('file-type');
+
+	const url = 'https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg';
 
 	(async () => {
-		const read = fs.createReadStream('encrypted.enc');
-		const decipher = crypto.createDecipheriv(alg, key, iv);
-		const stream = await fileType.stream(read.pipe(decipher), {sampleSize: 1024});
-
-		console.log(stream.fileType);
-		//=> {ext: 'mov', mime: 'video/quicktime'}
-
-		const write = fs.createWriteStream(`decrypted.${stream.fileType.ext}`);
-		stream.pipe(write);
+		const stream1 = got.stream(url);
+		const stream2 = await FileType.stream(stream1, {sampleSize: 1024});
+		if (stream2.fileType && stream2.fileType.mime === 'image/jpeg') {
+			// stream2 can be used to stream the JPEG image (from the very beginning of the stream)
+  	}
 	})();
 	```
 	*/
-	function stream(readableStream: ReadableStream, options?: IStreamOptions): Promise<core.ReadableStreamWithFileType>
+	function stream(readableStream: ReadableStream, options?: StreamOptions): Promise<core.ReadableStreamWithFileType>
 }
 
 export = core;

--- a/core.d.ts
+++ b/core.d.ts
@@ -357,7 +357,7 @@ declare namespace core {
 
 	interface StreamOptions {
 		/**
-		Sample size in bytes.
+		Overrides the default sample size of 4100 bytes.
 		*/
 		readonly sampleSize?: number
 	}

--- a/core.d.ts
+++ b/core.d.ts
@@ -355,13 +355,10 @@ declare namespace core {
 	*/
 	const mimeTypes: Set<core.MimeType>;
 
-	/**
-	 * Option object, used by `stream()`.
-	 */
 	interface StreamOptions {
 		/**
-		 *  Sample size in bytes.
-		 */
+		Sample size in bytes.
+		*/
 		readonly sampleSize?: number
 	}
 
@@ -373,25 +370,25 @@ declare namespace core {
 	The sample size impacts the file detection resolution.
 	A smaller sample size will result in lower probability of the best file type detection.
 
-	 *Note:* This method is only available using Node.js.
+	*Note:* This method is only available when using Node.js.
 
 	@param readableStream - A [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) containing a file to examine.
-	@param options - Option object
 	@returns A `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `FileType.fromFile()`.
 
 	@example
-	```js
-	const got = require('got');
-	const FileType = require('file-type');
+	```
+	import got = require('got');
+	import FileType = require('file-type');
 
 	const url = 'https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg';
 
 	(async () => {
 		const stream1 = got.stream(url);
 		const stream2 = await FileType.stream(stream1, {sampleSize: 1024});
+
 		if (stream2.fileType && stream2.fileType.mime === 'image/jpeg') {
 			// stream2 can be used to stream the JPEG image (from the very beginning of the stream)
-  	}
+  		}
 	})();
 	```
 	*/

--- a/core.js
+++ b/core.js
@@ -1436,7 +1436,6 @@ const stream = readableStream => new Promise((resolve, reject) => {
 			const fileType = await fromBuffer(chunk);
 			pass.fileType = fileType;
 		} catch (error) {
-			reject(error);
 			if (error instanceof strtok3.EndOfStreamError) {
 				pass.fileType = undefined;
 			} else {

--- a/core.js
+++ b/core.js
@@ -1414,9 +1414,14 @@ async function _fromTokenizer(tokenizer) {
 	}
 }
 
-const stream = readableStream => new Promise((resolve, reject) => {
+const stream = (readableStream, options) => new Promise((resolve, reject) => {
 	// Using `eval` to work around issues when bundling with Webpack
 	const stream = eval('require')('stream'); // eslint-disable-line no-eval
+
+	options = {
+		sampleSize: minimumBytes,
+		...options
+	};
 
 	readableStream.on('error', reject);
 	readableStream.once('readable', async () => {
@@ -1431,7 +1436,7 @@ const stream = readableStream => new Promise((resolve, reject) => {
 		}
 
 		// Read the input stream and detect the filetype
-		const chunk = readableStream.read(minimumBytes) || readableStream.read() || Buffer.alloc(0);
+		const chunk = readableStream.read(options.sampleSize) || readableStream.read() || Buffer.alloc(0);
 		try {
 			const fileType = await fromBuffer(chunk);
 			pass.fileType = fileType;

--- a/core.js
+++ b/core.js
@@ -1437,6 +1437,11 @@ const stream = readableStream => new Promise((resolve, reject) => {
 			pass.fileType = fileType;
 		} catch (error) {
 			reject(error);
+			if (error instanceof strtok3.EndOfStreamError) {
+				pass.fileType = undefined;
+			} else {
+				reject(error);
+			}
 		}
 
 		resolve(outputStream);

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
 	},
 	"dependencies": {
 		"readable-web-to-node-stream": "^3.0.0",
-		"strtok3": "^6.1.1",
+		"strtok3": "~6.1.3",
 		"token-types": "^3.0.0"
 	},
 	"xo": {

--- a/readme.md
+++ b/readme.md
@@ -287,19 +287,22 @@ Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample
 The sample size impacts the file detection resolution.
 A smaller sample size will result in lower probability of the best file type detection.
 
-*Note:* This method is only available using Node.js.
+*Note:* This method is only available when using Node.js.
 
 #### readableStream
-Type: [`Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
+
+Type: [`stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
 
 #### options
-Type: `Object`, for example:
-```js
-{ sampleSize: 400 }
-```
+
+Type: `object`
 
 ##### sampleSize
-Type: `number`, change default sample size of 4100 bytes.
+
+Type: `number`\
+Default: `4100`
+
+The sample size in bytes.
 
 #### Example
 
@@ -317,7 +320,6 @@ const url = 'https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg';
 	}
 })();
 ```
-
 
 #### readableStream
 

--- a/readme.md
+++ b/readme.md
@@ -278,19 +278,46 @@ Type: [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer)
 
 A file source implementing the [tokenizer interface](https://github.com/Borewit/strtok3#tokenizer).
 
-### FileType.stream(readableStream, sampleSize)
-
-Detect the file type of a readable stream.
-
-If `sampleSize` is not provided, a backward compatible sample size of 4100 bytes is used.
+### FileType.stream(readableStream, options?)
 
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `FileType.fromFile()`.
 
 This method can be handy to put in between a stream, but it comes with a price.
 Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample, to determine the file type.
-The sample size impacts the file detection resolution. A smaller sample size will result in lower probability of the best file type detection.
+The sample size impacts the file detection resolution.
+A smaller sample size will result in lower probability of the best file type detection.
 
 *Note:* This method is only available using Node.js.
+
+#### readableStream
+Type: [`Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
+
+#### options
+Type: `Object`, for example:
+```js
+{ sampleSize: 400 }
+```
+
+##### sampleSize
+Type: `number`, change default sample size of 4100 bytes.
+
+#### Example
+
+```js
+const got = require('got');
+const FileType = require('file-type');
+
+const url = 'https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg';
+
+(async () => {
+	const stream1 = got.stream(url);
+	const stream2 = await FileType.stream(stream1, {sampleSize: 1024});
+	if (stream2.fileType && stream2.fileType.mime === 'image/jpeg') {
+		// stream2 can be used to stream the JPEG image (from the very beginning of the stream)
+	}
+})();
+```
+
 
 #### readableStream
 

--- a/readme.md
+++ b/readme.md
@@ -315,6 +315,7 @@ const url = 'https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg';
 (async () => {
 	const stream1 = got.stream(url);
 	const stream2 = await FileType.stream(stream1, {sampleSize: 1024});
+
 	if (stream2.fileType && stream2.fileType.mime === 'image/jpeg') {
 		// stream2 can be used to stream the JPEG image (from the very beginning of the stream)
 	}

--- a/readme.md
+++ b/readme.md
@@ -278,11 +278,17 @@ Type: [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer)
 
 A file source implementing the [tokenizer interface](https://github.com/Borewit/strtok3#tokenizer).
 
-### FileType.stream(readableStream)
+### FileType.stream(readableStream, sampleSize)
 
 Detect the file type of a readable stream.
 
+If `sampleSize` is not provided, a backward compatible sample size of 4100 bytes is used.
+
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `FileType.fromFile()`.
+
+This method can be handy to put in between a stream, but it comes with a price.
+Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample, to determine the file type.
+The sample size impacts the file detection resolution. A smaller sample size will result in lower probability of the best file type detection.
 
 *Note:* This method is only available using Node.js.
 

--- a/test.js
+++ b/test.js
@@ -337,6 +337,12 @@ test('.stream() method - short stream', async t => {
 	t.deepEqual(bufferA, bufferB);
 });
 
+test('.stream() method - no End-Of-Stream errors', async t => {
+	const file = path.join(__dirname, 'fixture', 'fixture.ogm');
+	const stream = await FileType.stream(fs.createReadStream(file), {sampleSize: 30});
+	t.is(stream.fileType, undefined);
+});
+
 test('.stream() method - error event', async t => {
 	const errorMessage = 'Fixture';
 
@@ -349,6 +355,16 @@ test('.stream() method - error event', async t => {
 	});
 
 	await t.throwsAsync(FileType.stream(readableStream), errorMessage);
+});
+
+test('.stream() method - sampleSize', async t => {
+	const file = path.join(__dirname, 'fixture', 'fixture.ogm');
+	let stream = await FileType.stream(fs.createReadStream(file), {sampleSize: 30});
+	t.is(typeof (stream.fileType), 'undefined', 'file-type cannot be determined with a sampleSize of 30');
+
+	stream = await FileType.stream(fs.createReadStream(file), {sampleSize: 4100});
+	t.is(typeof (stream.fileType), 'object', 'file-type can be determined with a sampleSize of 4100');
+	t.is(stream.fileType.mime, 'video/ogg');
 });
 
 test('FileType.extensions.has', t => {

--- a/test.js
+++ b/test.js
@@ -337,7 +337,7 @@ test('.stream() method - short stream', async t => {
 	t.deepEqual(bufferA, bufferB);
 });
 
-test('.stream() method - no End-Of-Stream errors', async t => {
+test('.stream() method - no end-of-stream errors', async t => {
 	const file = path.join(__dirname, 'fixture', 'fixture.ogm');
 	const stream = await FileType.stream(fs.createReadStream(file), {sampleSize: 30});
 	t.is(stream.fileType, undefined);
@@ -357,7 +357,7 @@ test('.stream() method - error event', async t => {
 	await t.throwsAsync(FileType.stream(readableStream), errorMessage);
 });
 
-test('.stream() method - sampleSize', async t => {
+test('.stream() method - sampleSize option', async t => {
 	const file = path.join(__dirname, 'fixture', 'fixture.ogm');
 	let stream = await FileType.stream(fs.createReadStream(file), {sampleSize: 30});
 	t.is(typeof (stream.fileType), 'undefined', 'file-type cannot be determined with a sampleSize of 30');


### PR DESCRIPTION
Changes:
1. Document `stream()` limitation.
1. Make sample size in `stream()` configurable, and add corresponding unit tests

Includes PR: #468 (better to merge that one first)