### PR TITLE
Add support for VCF (and fix ICS detection)

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -238,6 +238,7 @@ declare namespace core {
 		| 'application/dicom'
 		| 'audio/x-musepack'
 		| 'text/calendar'
+		| 'text/vcard'
 		| 'model/gltf-binary'
 		| 'application/vnd.tcpdump.pcap'
 		| 'audio/x-dsf' // Non-standard

--- a/core.d.ts
+++ b/core.d.ts
@@ -138,7 +138,8 @@ declare namespace core {
 		| 'stl'
 		| 'chm'
 		| '3mf'
-		| 'zst';
+		| 'zst'
+		| 'vcf';
 
 	type MimeType =
 		| 'image/jpeg'

--- a/core.js
+++ b/core.js
@@ -911,7 +911,7 @@ async function _fromTokenizer(tokenizer) {
 		};
 	}
 
-	if (checkString('BEGIN:VCALENDAR')) {
+	if (checkString('BEGIN:VCALEN')) { // limit to 12 characters as precised in bytesRead const
 		return {
 			ext: 'ics',
 			mime: 'text/calendar'

--- a/core.js
+++ b/core.js
@@ -918,6 +918,13 @@ async function _fromTokenizer(tokenizer) {
 		};
 	}
 
+	if (checkString('BEGIN:VCARD')) {
+		return {
+			ext: 'vcf',
+			mime: 'text/vcard'
+		};
+	}
+
 	if (check([0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C])) {
 		return {
 			ext: '7z',

--- a/core.js
+++ b/core.js
@@ -911,7 +911,7 @@ async function _fromTokenizer(tokenizer) {
 		};
 	}
 
-	if (checkString('BEGIN:VCALEN')) { // limit to 12 characters as precised in bytesRead const
+	if (checkString('BEGIN:VCALEN')) { // Limit to 12 characters as precised in bytesRead const
 		return {
 			ext: 'ics',
 			mime: 'text/calendar'

--- a/core.js
+++ b/core.js
@@ -911,7 +911,7 @@ async function _fromTokenizer(tokenizer) {
 		};
 	}
 
-	if (checkString('BEGIN:')) {
+	if (checkString('BEGIN:VCALENDAR')) {
 		return {
 			ext: 'ics',
 			mime: 'text/calendar'

--- a/core.js
+++ b/core.js
@@ -911,20 +911,6 @@ async function _fromTokenizer(tokenizer) {
 		};
 	}
 
-	if (checkString('BEGIN:VCALEN')) { // Limit to 12 characters as precised in bytesRead const
-		return {
-			ext: 'ics',
-			mime: 'text/calendar'
-		};
-	}
-
-	if (checkString('BEGIN:VCARD')) {
-		return {
-			ext: 'vcf',
-			mime: 'text/vcard'
-		};
-	}
-
 	if (check([0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C])) {
 		return {
 			ext: '7z',
@@ -1212,6 +1198,24 @@ async function _fromTokenizer(tokenizer) {
 
 	// Increase sample size from 12 to 256.
 	await tokenizer.peekBuffer(buffer, {length: Math.min(256, tokenizer.fileInfo.size), mayBeLess: true});
+
+	// -- 15-byte signatures --
+
+	if (checkString('BEGIN:')) {
+		if (checkString('VCARD', {offset: 6})) {
+			return {
+				ext: 'vcf',
+				mime: 'text/vcard'
+			};
+		}
+
+		if (checkString('VCALENDAR', {offset: 6})) {
+			return {
+				ext: 'ics',
+				mime: 'text/calendar'
+			};
+		}
+	}
 
 	// `raf` is here just to keep all the raw image detectors together.
 	if (checkString('FUJIFILMCCD-RAW')) {

--- a/fixture/fixture.vcf
+++ b/fixture/fixture.vcf
@@ -1,0 +1,16 @@
+BEGIN:VCARD
+VERSION:3.0
+N:Gump;Forrest;;Mr.,;
+FN:Forrest Gump
+ORG:Bubba Gump Shrimp Co.
+TITLE:Shrimp Man
+PHOTO;VALUE=URI;TYPE=GIF:http://www.example.com/dir_photos/my_photo.gif
+TEL;TYPE=WORK,VOICE:(111) 555-1212
+TEL;TYPE=HOME,VOICE:(404) 555-1212
+ADR;TYPE=WORK,PREF:;;100 Waters Edge;Baytown;LA;30314;United States of America
+LABEL;TYPE=WORK,PREF:100 Waters Edge\nBaytown\, LA 30314\nUnited States of America
+ADR;TYPE=HOME:;;42 Plantation St.;Baytown;LA;30314;United States of America
+LABEL;TYPE=HOME:42 Plantation St.\nBaytown\, LA 30314\nUnited States of America
+EMAIL:forrestgump@example.com
+REV:2008-04-24T19:52:43Z
+END:VCARD

--- a/package.json
+++ b/package.json
@@ -182,7 +182,8 @@
 		"stl",
 		"chm",
 		"3mf",
-		"zst"
+		"zst",
+		"vcf"
 	],
 	"devDependencies": {
 		"@types/node": "^13.1.4",

--- a/readme.md
+++ b/readme.md
@@ -373,6 +373,7 @@ Returns a set of supported MIME types.
 - [`dcm`](https://en.wikipedia.org/wiki/DICOM#Data_format) - DICOM Image File
 - [`mpc`](https://en.wikipedia.org/wiki/Musepack) - Musepack (SV7 & SV8)
 - [`ics`](https://en.wikipedia.org/wiki/ICalendar#Data_format) - iCalendar
+- [`vcf`](https://en.wikipedia.org/wiki/VCard) - vCard
 - [`glb`](https://github.com/KhronosGroup/glTF) - GL Transmission Format
 - [`pcap`](https://wiki.wireshark.org/Development/LibpcapFileFormat) - Libpcap File Format
 - [`dsf`](https://dsd-guide.com/sites/default/files/white-papers/DSFFileFormatSpec_E.pdf) - Sony DSD Stream File (DSF)

--- a/supported.js
+++ b/supported.js
@@ -136,7 +136,8 @@ module.exports = {
 		'stl',
 		'chm',
 		'3mf',
-		'zst'
+		'zst',
+		'vcf'
 	],
 	mimeTypes: [
 		'image/jpeg',

--- a/supported.js
+++ b/supported.js
@@ -236,6 +236,7 @@ module.exports = {
 		'application/dicom',
 		'audio/x-musepack',
 		'text/calendar',
+		'text/vcard',
 		'model/gltf-binary',
 		'application/vnd.tcpdump.pcap',
 		'audio/x-dsf', // Non-standard


### PR DESCRIPTION
Link to the wiki page : https://en.wikipedia.org/wiki/VCard

If you're adding support for a new file type, please follow the below steps:

- **One PR per file type.**
- [x] Add a fixture file named `fixture.<extension>` to the `fixture` directory.
- [x] Add the file extension to the `extensions` array in `supported.js`.
- [x] Add the file's MIME type to the `types` array in `supported.js`.
- [x] Add the file type detection logic to the `core.js` file.
- [x] Add the file extension to the `FileType` type in `core.d.ts`.
- [x] Add the file's MIME type to the `MimeType` type in `core.d.ts`.
- [x] Add the file extension to the `Supported file types` section in the readme, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```
- [x] Add the file extension to the `keywords` array in the `package.json` file.
- [x] Run `$ npm test` to ensure the tests pass.
- [x] Open a pull request with a title like `Add support for Format`, for example, `Add support for PNG`.
- [x] The pull request description should include a link to the official page of the file format or some other source. Also include a link to where you found the file type detection / magic bytes and the MIME type.
