### PR TITLE
Update dependency to token-types v3, supporting BigInt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 16
           - 14
           - 12
           - 10
-          - 8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/core.js
+++ b/core.js
@@ -1067,7 +1067,7 @@ async function _fromTokenizer(tokenizer) {
 			await tokenizer.readBuffer(guid);
 			return {
 				id: guid,
-				size: await tokenizer.readToken(Token.UINT64_LE)
+				size: Number(await tokenizer.readToken(Token.UINT64_LE))
 			};
 		}
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10"
 	},
 	"scripts": {
 		"ava": "ava --serial --verbose",
@@ -197,8 +197,8 @@
 	},
 	"dependencies": {
 		"readable-web-to-node-stream": "^3.0.0",
-		"strtok3": "^6.0.3",
-		"token-types": "^2.0.0"
+		"strtok3": "^6.1.1",
+		"token-types": "^3.0.0"
 	},
 	"xo": {
 		"envs": [


### PR DESCRIPTION
Update dependency to [token-types v3](https://github.com/Borewit/token-types/releases/tag/v3.0.0), supporting [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)

- [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) requires Node version 10, updated module engine API requirement.
- Update [strtok3](https://github.com/Borewit/strtok3) to [v6.1.0](https://github.com/Borewit/strtok3/releases/tag/v6.1.0) to allign the dependent token-types version.

Related: Borewit/token-types#300
