### PR TITLE
Update to token-types 4.0.1 & strtok3 6.2.2

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -301,10 +301,10 @@ declare namespace core {
 
 	If file access is available, it is recommended to use `.fromFile()` instead.
 
-	@param buffer - A buffer representing file data. It works best if the buffer contains the entire file, it may work with a smaller portion as well.
+	@param buffer - An Uint8Array or Buffer representing file data. It works best if the buffer contains the entire file, it may work with a smaller portion as well.
 	@returns The detected file type and MIME type, or `undefined` when there is no match.
 	*/
-	function fromBuffer(buffer: Buffer | Uint8Array | ArrayBuffer): Promise<core.FileTypeResult | undefined>;
+	function fromBuffer(buffer: Uint8Array | ArrayBuffer): Promise<core.FileTypeResult | undefined>;
 
 	/**
 	Detect the file type of a Node.js [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).

--- a/core.js
+++ b/core.js
@@ -20,11 +20,11 @@ async function fromStream(stream) {
 }
 
 async function fromBuffer(input) {
-	if (!(input instanceof Uint8Array || input instanceof ArrayBuffer || Buffer.isBuffer(input))) {
+	if (!(input instanceof Uint8Array || input instanceof ArrayBuffer)) {
 		throw new TypeError(`Expected the \`input\` argument to be of type \`Uint8Array\` or \`Buffer\` or \`ArrayBuffer\`, got \`${typeof input}\``);
 	}
 
-	const buffer = input instanceof Buffer ? input : Buffer.from(input);
+	const buffer = input instanceof Uint8Array ? input : new Uint8Array(input);
 
 	if (!(buffer && buffer.length > 1)) {
 		return;

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
 		"vcf"
 	],
 	"devDependencies": {
+		"@tokenizer/token": "^0.3.0",
 		"@types/node": "^13.1.4",
 		"ava": "^2.3.0",
 		"noop-stream": "^0.1.0",
@@ -196,9 +197,9 @@
 		"xo": "^0.25.3"
 	},
 	"dependencies": {
-		"readable-web-to-node-stream": "^3.0.0",
-		"strtok3": "^6.1.1",
-		"token-types": "^3.0.0"
+		"readable-web-to-node-stream": "^3.0.2",
+		"strtok3": "^6.2.2",
+		"token-types": "^4.0.1"
 	},
 	"xo": {
 		"envs": [


### PR DESCRIPTION
Changes:
1. Update to [token-types 4.0.1](https://github.com/Borewit/token-types/releases/tag/v4.1.0) & [strtok3 6.2.2](https://github.com/Borewit/strtok3/releases/tag/v6.2.2)
1. The updated dependencies try to abstract Buffer dependency by using `Uint8Array` where possible.
1. Remove `Buffer` as type, as `Buffer` is a sublcass of `Uint8Array`.
1. Add [@tokenizer/token](https://github.com/Borewit/tokenizer-token) to development dependencies. This was not required in the past as [@tokenizer/token](https://github.com/Borewit/tokenizer-token) was incorrectly included indirectly as a normal dependency.

Dependent PR: Borewit/music-metadata#852, to align dependencies [token-types](https://github.com/Borewit/token-types) & [strtok3](https://github.com/Borewit/strtok3)

Dependency on `Buffer` is still there, but in some dependent module the `Buffer` dependency has been entirely abstracted to `Uint8Array`. Let's say I try to get rid of Buffer dependencies if not really required.

By doing this, I hope on the long run I hope modules will be better suitable for multipurpose (Node.js & browser) usage.

Fixes:
* #469