### PR TITLE
Prevent End-Of-Stream error in `stream()`

### DIFF
--- a/core.js
+++ b/core.js
@@ -1436,7 +1436,6 @@ const stream = readableStream => new Promise((resolve, reject) => {
 			const fileType = await fromBuffer(chunk);
 			pass.fileType = fileType;
 		} catch (error) {
-			reject(error);
 			if (error instanceof strtok3.EndOfStreamError) {
 				pass.fileType = undefined;
 			} else {

--- a/core.js
+++ b/core.js
@@ -1437,6 +1437,11 @@ const stream = readableStream => new Promise((resolve, reject) => {
 			pass.fileType = fileType;
 		} catch (error) {
 			reject(error);
+			if (error instanceof strtok3.EndOfStreamError) {
+				pass.fileType = undefined;
+			} else {
+				reject(error);
+			}
 		}
 
 		resolve(outputStream);

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
 	},
 	"dependencies": {
 		"readable-web-to-node-stream": "^3.0.0",
-		"strtok3": "^6.1.1",
+		"strtok3": "~6.1.3",
 		"token-types": "^3.0.0"
 	},
 	"xo": {


### PR DESCRIPTION
Suppress the End-Of-Stream, instead assign `undefined` to `stream.fileType`.
Restrict updating strtok3 to minor version.

Fixes: 
* #467
* #469
