### PR TITLE
Update dependencies token-types & xo

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,12 +194,12 @@
 		"noop-stream": "^0.1.0",
 		"read-chunk": "^3.2.0",
 		"tsd": "^0.11.0",
-		"xo": "^0.25.3"
+		"xo": "^0.25.4"
 	},
 	"dependencies": {
 		"readable-web-to-node-stream": "^3.0.2",
 		"strtok3": "^6.2.2",
-		"token-types": "^4.0.1"
+		"token-types": "^4.1.0"
 	},
 	"xo": {
 		"envs": [


### PR DESCRIPTION
Update to latest dependencies.

Would be great to have release using the latest dependencies rather then the older locked.
I getting [weird errors](Borewit/audio-tag-analyzer#56), maybe caused by [conflicting versions in dependencies](https://npmgraph.js.org/?q=music-metadata-browser), in version [v16.5.2](https://github.com/sindresorhus/file-type/releases/tag/v16.5.2)

#466 Solved compatibility issues (#469) with the new libraries.