### PR TITLE
Update strtok3 to 7.0.0-alpha.4 to improve ESM behavior

### DIFF
--- a/core.js
+++ b/core.js
@@ -70,7 +70,7 @@ async function _fromTokenizer(tokenizer) {
 	const checkString = (header, options) => check(stringToBytes(header), options);
 
 	// Keep reading until EOF if the file size is unknown.
-	if (tokenizer.fileInfo.size === 0) {
+	if (tokenizer.fileInfo.size === undefined) {
 		tokenizer.fileInfo.size = Number.MAX_SAFE_INTEGER;
 	}
 

--- a/core.js
+++ b/core.js
@@ -1,9 +1,5 @@
 import Token from 'token-types';
-import {
-	fromStream as tokenizerFromStream,
-	fromBuffer as tokenizerFromBuffer,
-	EndOfStreamError,
-} from 'strtok3/lib/core.js';
+import * as strtok3 from 'strtok3/core';
 import {
 	stringToBytes,
 	tarHeaderChecksumMatches,
@@ -14,7 +10,7 @@ import {extensions, mimeTypes} from './supported.js';
 const minimumBytes = 4100; // A fair amount of file-types are detectable within this range.
 
 export async function fileTypeFromStream(stream) {
-	const tokenizer = await tokenizerFromStream(stream);
+	const tokenizer = await strtok3.fromStream(stream);
 	try {
 		return await fileTypeFromTokenizer(tokenizer);
 	} finally {
@@ -33,7 +29,7 @@ export async function fileTypeFromBuffer(input) {
 		return;
 	}
 
-	return fileTypeFromTokenizer(tokenizerFromBuffer(buffer));
+	return fileTypeFromTokenizer(strtok3.fromBuffer(buffer));
 }
 
 function _check(buffer, headers, options) {
@@ -61,7 +57,7 @@ export async function fileTypeFromTokenizer(tokenizer) {
 	try {
 		return _fromTokenizer(tokenizer);
 	} catch (error) {
-		if (!(error instanceof EndOfStreamError)) {
+		if (!(error instanceof strtok3.EndOfStreamError)) {
 			throw error;
 		}
 	}
@@ -369,7 +365,7 @@ async function _fromTokenizer(tokenizer) {
 				}
 			}
 		} catch (error) {
-			if (!(error instanceof EndOfStreamError)) {
+			if (!(error instanceof strtok3.EndOfStreamError)) {
 				throw error;
 			}
 		}
@@ -1437,7 +1433,7 @@ export async function fileTypeStream(readableStream, {sampleSize = minimumBytes}
 						const fileType = await fileTypeFromBuffer(chunk);
 						pass.fileType = fileType;
 					} catch (error) {
-						if (error instanceof EndOfStreamError) {
+						if (error instanceof strtok3.EndOfStreamError) {
 							pass.fileType = undefined;
 						} else {
 							reject(error);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import strtok3 from 'strtok3';
+import * as strtok3 from 'strtok3';
 import {fileTypeFromTokenizer} from './core.js';
 
 export async function fileTypeFromFile(path) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -51,9 +51,9 @@ expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuff
 	}
 })();
 
-expectType<Set<FileExtension>>(supportedExtensions);
+expectType<ReadonlySet<FileExtension>>(supportedExtensions);
 
-expectType<Set<MimeType>>(supportedMimeTypes);
+expectType<ReadonlySet<MimeType>>(supportedMimeTypes);
 
 const readableStream = fs.createReadStream('file.png');
 const streamWithFileType = fileTypeStream(readableStream);

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
 	],
 	"dependencies": {
 		"readable-web-to-node-stream": "^3.0.2",
-		"strtok3": "^7.0.0-alpha.3",
+		"strtok3": "^7.0.0-alpha.4",
 		"token-types": "^4.1.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
 	],
 	"dependencies": {
 		"readable-web-to-node-stream": "^3.0.2",
-		"strtok3": "^6.2.2",
+		"strtok3": "^7.0.0-alpha.3",
 		"token-types": "^4.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Related:
- Borewit/strtok3#533
- Borewit/peek-readable#339
- Borewit/readable-web-to-node-stream#476