### PR TITLE
Update strtok3 & token-types for explicit `node:buffer` imports

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,5 +1,5 @@
 import {Buffer} from 'node:buffer';
-import Token from 'token-types';
+import * as Token from 'token-types';
 import * as strtok3 from 'strtok3/core';
 import {
 	stringToBytes,

--- a/package.json
+++ b/package.json
@@ -196,8 +196,8 @@
 	],
 	"dependencies": {
 		"readable-web-to-node-stream": "^3.0.2",
-		"strtok3": "7.0.0-alpha.4",
-		"token-types": "^4.1.1"
+		"strtok3": "^7.0.0-alpha.5",
+		"token-types": "^5.0.0-alpha.0"
 	},
 	"devDependencies": {
 		"@tokenizer/token": "^0.3.0",


### PR DESCRIPTION
Update "strtok3" to ^[7.0.0-alpha.5](https://github.com/Borewit/strtok3/releases/tag/v7.0.0-alpha.5)
Update "token-types" to ^[5.0.0-alpha.0](https://github.com/Borewit/token-types/releases/tag/v5.0.0-alpha.0) (first ES module).

Fixes #502