### PR TITLE
Supported files list in readme.md sorted

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -318,144 +318,144 @@ Returns a `Set<string>` of supported MIME types.
 
 ## Supported file types
 
-- [`jpg`](https://en.wikipedia.org/wiki/JPEG) - Joint Photographic Experts Group image
-- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics
+- [`3g2`](https://en.wikipedia.org/wiki/3GP_and_3G2#3G2) - Multimedia container format defined by the 3GPP2 for 3G CDMA2000 multimedia services
+- [`3gp`](https://en.wikipedia.org/wiki/3GP_and_3G2#3GP) - Multimedia container format defined by the Third Generation Partnership Project (3GPP) for 3G UMTS multimedia services
+- [`3mf`](https://en.wikipedia.org/wiki/3D_Manufacturing_Format) - 3D Manufacturing Format
+- [`7z`](https://en.wikipedia.org/wiki/7z) - 7-Zip archive
+- [`Z`](https://fileinfo.com/extension/z) - Unix Compressed File
+- [`aac`](https://en.wikipedia.org/wiki/Advanced_Audio_Coding) - Advanced Audio Coding
+- [`ac3`](https://www.atsc.org/standard/a522012-digital-audio-compression-ac-3-e-ac-3-standard-12172012/) - ATSC A/52 Audio File
+- [`ai`](https://en.wikipedia.org/wiki/Adobe_Illustrator_Artwork) - Adobe Illustrator Artwork
+- [`aif`](https://en.wikipedia.org/wiki/Audio_Interchange_File_Format) - Audio Interchange file
+- [`alias`](https://en.wikipedia.org/wiki/Alias_%28Mac_OS%29) - macOS Alias file
+- [`amr`](https://en.wikipedia.org/wiki/Adaptive_Multi-Rate_audio_codec) - Adaptive Multi-Rate audio codec
+- [`ape`](https://en.wikipedia.org/wiki/Monkey%27s_Audio) - Monkey's Audio
 - [`apng`](https://en.wikipedia.org/wiki/APNG) - Animated Portable Network Graphics
-- [`gif`](https://en.wikipedia.org/wiki/GIF) - Graphics Interchange Format
-- [`webp`](https://en.wikipedia.org/wiki/WebP) - Web Picture format
-- [`flif`](https://en.wikipedia.org/wiki/Free_Lossless_Image_Format) - Free Lossless Image Format
-- [`xcf`](https://en.wikipedia.org/wiki/XCF_(file_format)) - eXperimental Computing Facility
+- [`ar`](https://en.wikipedia.org/wiki/Ar_(Unix)) - Archive file
+- [`arrow`](https://arrow.apache.org) - Columnar format for tables of data
+- [`arw`](https://en.wikipedia.org/wiki/Raw_image_format#ARW) - Sony Alpha Raw image file
+- [`asar`](https://github.com/electron/asar#format) - Archive format primarily used to enclose Electron applications
+- [`asf`](https://en.wikipedia.org/wiki/Advanced_Systems_Format) - Advanced Systems Format
+- [`avi`](https://en.wikipedia.org/wiki/Audio_Video_Interleave) - Audio Video Interleave file
+- [`avif`](https://en.wikipedia.org/wiki/AV1#AV1_Image_File_Format_(AVIF)) - AV1 Image File Format
+- [`blend`](https://wiki.blender.org/index.php/Dev:Source/Architecture/File_Format) - Blender project
+- [`bmp`](https://en.wikipedia.org/wiki/BMP_file_format) - Bitmap image file
+- [`bpg`](https://bellard.org/bpg/) - Better Portable Graphics file
+- [`bz2`](https://en.wikipedia.org/wiki/Bzip2) - Archive file
+- [`cab`](https://en.wikipedia.org/wiki/Cabinet_(file_format)) - Cabinet file
+- [`cfb`](https://en.wikipedia.org/wiki/Compound_File_Binary_Format) - Compount File Binary Format
+- [`chm`](https://en.wikipedia.org/wiki/Microsoft_Compiled_HTML_Help) - Microsoft Compiled HTML Help
 - [`cr2`](https://fileinfo.com/extension/cr2) - Canon Raw image file (v2)
 - [`cr3`](https://fileinfo.com/extension/cr3) - Canon Raw image file (v3)
-- [`orf`](https://en.wikipedia.org/wiki/ORF_format) - Olympus Raw image file
-- [`arw`](https://en.wikipedia.org/wiki/Raw_image_format#ARW) - Sony Alpha Raw image file
-- [`dng`](https://en.wikipedia.org/wiki/Digital_Negative) - Adobe Digital Negative image file
-- [`nef`](https://www.nikonusa.com/en/learn-and-explore/a/products-and-innovation/nikon-electronic-format-nef.html) - Nikon Electronic Format image file
-- [`rw2`](https://en.wikipedia.org/wiki/Raw_image_format) - Panasonic RAW image file
-- [`raf`](https://en.wikipedia.org/wiki/Raw_image_format) - Fujifilm RAW image file
-- [`tif`](https://en.wikipedia.org/wiki/Tagged_Image_File_Format) - Tagged Image file
-- [`bmp`](https://en.wikipedia.org/wiki/BMP_file_format) - Bitmap image file
-- [`icns`](https://en.wikipedia.org/wiki/Apple_Icon_Image_format) - Apple Icon image
-- [`jxr`](https://en.wikipedia.org/wiki/JPEG_XR) - Joint Photographic Experts Group extended range
-- [`psd`](https://en.wikipedia.org/wiki/Adobe_Photoshop#File_format) - Adobe Photoshop document
-- [`indd`](https://en.wikipedia.org/wiki/Adobe_InDesign#File_format) - Adobe InDesign document
-- [`zip`](https://en.wikipedia.org/wiki/Zip_(file_format)) - Archive file
-- [`tar`](https://en.wikipedia.org/wiki/Tar_(computing)#File_format) - Tarball archive file
-- [`rar`](https://en.wikipedia.org/wiki/RAR_(file_format)) - Archive file
-- [`gz`](https://en.wikipedia.org/wiki/Gzip) - Archive file
-- [`bz2`](https://en.wikipedia.org/wiki/Bzip2) - Archive file
-- [`zst`](https://en.wikipedia.org/wiki/Zstandard) - Archive file
-- [`7z`](https://en.wikipedia.org/wiki/7z) - 7-Zip archive
+- [`crx`](https://developer.chrome.com/extensions/crx) - Google Chrome extension
+- [`cur`](https://en.wikipedia.org/wiki/ICO_(file_format)) - Icon file
+- [`dcm`](https://en.wikipedia.org/wiki/DICOM#Data_format) - DICOM Image File
+- [`deb`](https://en.wikipedia.org/wiki/Deb_(file_format)) - Debian package
 - [`dmg`](https://en.wikipedia.org/wiki/Apple_Disk_Image) - Apple Disk Image
-- [`mp4`](https://en.wikipedia.org/wiki/MPEG-4_Part_14#Filename_extensions) - MPEG-4 Part 14 video file
+- [`dng`](https://en.wikipedia.org/wiki/Digital_Negative) - Adobe Digital Negative image file
+- [`docx`](https://en.wikipedia.org/wiki/Office_Open_XML) - Microsoft Word
+- [`dsf`](https://dsd-guide.com/sites/default/files/white-papers/DSFFileFormatSpec_E.pdf) - Sony DSD Stream File (DSF)
+- [`eot`](https://en.wikipedia.org/wiki/Embedded_OpenType) - Embedded OpenType font
+- [`eps`](https://en.wikipedia.org/wiki/Encapsulated_PostScript) - Encapsulated PostScript
+- [`epub`](https://en.wikipedia.org/wiki/EPUB) - E-book file
+- [`exe`](https://en.wikipedia.org/wiki/.exe) - Executable file
+- [`f4a`](https://en.wikipedia.org/wiki/Flash_Video) - Audio-only ISO base media file format used by Adobe Flash Player
+- [`f4b`](https://en.wikipedia.org/wiki/Flash_Video) - Audiobook and podcast ISO base media file format used by Adobe Flash Player
+- [`f4p`](https://en.wikipedia.org/wiki/Flash_Video) - ISO base media file format protected by Adobe Access DRM used by Adobe Flash Player
+- [`f4v`](https://en.wikipedia.org/wiki/Flash_Video) - ISO base media file format used by Adobe Flash Player
+- [`flac`](https://en.wikipedia.org/wiki/FLAC) - Free Lossless Audio Codec
+- [`flif`](https://en.wikipedia.org/wiki/Free_Lossless_Image_Format) - Free Lossless Image Format
+- [`flv`](https://en.wikipedia.org/wiki/Flash_Video) - Flash video
+- [`gif`](https://en.wikipedia.org/wiki/GIF) - Graphics Interchange Format
+- [`glb`](https://github.com/KhronosGroup/glTF) - GL Transmission Format
+- [`gz`](https://en.wikipedia.org/wiki/Gzip) - Archive file
+- [`heic`](https://nokiatech.github.io/heif/technical.html) - High Efficiency Image File Format
+- [`icns`](https://en.wikipedia.org/wiki/Apple_Icon_Image_format) - Apple Icon image
+- [`ico`](https://en.wikipedia.org/wiki/ICO_(file_format)) - Windows icon file
+- [`ics`](https://en.wikipedia.org/wiki/ICalendar#Data_format) - iCalendar
+- [`indd`](https://en.wikipedia.org/wiki/Adobe_InDesign#File_format) - Adobe InDesign document
+- [`it`](https://wiki.openmpt.org/Manual:_Module_formats#The_Impulse_Tracker_format_.28.it.29) - Audio module format: Impulse Tracker
+- [`jp2`](https://en.wikipedia.org/wiki/JPEG_2000) - JPEG 2000
+- [`jpg`](https://en.wikipedia.org/wiki/JPEG) - Joint Photographic Experts Group image
+- [`jpm`](https://en.wikipedia.org/wiki/JPEG_2000) - JPEG 2000
+- [`jpx`](https://en.wikipedia.org/wiki/JPEG_2000) - JPEG 2000
+- [`jxl`](https://en.wikipedia.org/wiki/JPEG_XL) - JPEG XL image format
+- [`jxr`](https://en.wikipedia.org/wiki/JPEG_XR) - Joint Photographic Experts Group extended range
+- [`ktx`](https://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/) - OpenGL and OpenGL ES textures
+- [`lnk`](https://en.wikipedia.org/wiki/Shortcut_%28computing%29#Microsoft_Windows) - Microsoft Windows file shortcut
+- [`lz`](https://en.wikipedia.org/wiki/Lzip) - Arhive file
+- [`lzh`](https://en.wikipedia.org/wiki/LHA_(file_format)) - LZH archive
+- [`m4a`](https://en.wikipedia.org/wiki/M4A) - Audio-only MPEG-4 files
+- [`m4b`](https://en.wikipedia.org/wiki/M4B) - Audiobook and podcast MPEG-4 files, which also contain metadata including chapter markers, images, and hyperlinks
+- [`m4p`](https://en.wikipedia.org/wiki/MPEG-4_Part_14#Filename_extensions) - MPEG-4 files with audio streams encrypted by FairPlay Digital Rights Management as were sold through the iTunes Store
+- [`m4v`](https://en.wikipedia.org/wiki/M4V) -  MPEG-4 Visual bitstreams
 - [`mid`](https://en.wikipedia.org/wiki/MIDI) - Musical Instrument Digital Interface file
+- [`mie`](https://en.wikipedia.org/wiki/Sidecar_file) - Dedicated meta information format which supports storage of binary as well as textual meta information
+- [`mj2`](https://en.wikipedia.org/wiki/Motion_JPEG_2000) - Motion JPEG 2000
 - [`mkv`](https://en.wikipedia.org/wiki/Matroska) - Matroska video file
-- [`webm`](https://en.wikipedia.org/wiki/WebM) - Web video file
+- [`mobi`](https://en.wikipedia.org/wiki/Mobipocket) - Mobipocket
 - [`mov`](https://en.wikipedia.org/wiki/QuickTime_File_Format) - QuickTime video file
-- [`avi`](https://en.wikipedia.org/wiki/Audio_Video_Interleave) - Audio Video Interleave file
-- [`mpg`](https://en.wikipedia.org/wiki/MPEG-1) - MPEG-1 file
 - [`mp1`](https://en.wikipedia.org/wiki/MPEG-1_Audio_Layer_I) - MPEG-1 Audio Layer I
 - [`mp2`](https://en.wikipedia.org/wiki/MPEG-1_Audio_Layer_II) - MPEG-1 Audio Layer II
 - [`mp3`](https://en.wikipedia.org/wiki/MP3) - Audio file
-- [`ogg`](https://en.wikipedia.org/wiki/Ogg) - Audio file
-- [`ogv`](https://en.wikipedia.org/wiki/Ogg) - Audio file
-- [`ogm`](https://en.wikipedia.org/wiki/Ogg) - Audio file
+- [`mp4`](https://en.wikipedia.org/wiki/MPEG-4_Part_14#Filename_extensions) - MPEG-4 Part 14 video file
+- [`mpc`](https://en.wikipedia.org/wiki/Musepack) - Musepack (SV7 & SV8)
+- [`mpg`](https://en.wikipedia.org/wiki/MPEG-1) - MPEG-1 file
+- [`mts`](https://en.wikipedia.org/wiki/.m2ts) - MPEG-2 Transport Stream, both raw and Blu-ray Disc Audio-Video (BDAV) versions
+- [`mxf`](https://en.wikipedia.org/wiki/Material_Exchange_Format) - Material Exchange Format
+- [`nef`](https://www.nikonusa.com/en/learn-and-explore/a/products-and-innovation/nikon-electronic-format-nef.html) - Nikon Electronic Format image file
+- [`nes`](https://fileinfo.com/extension/nes) - Nintendo NES ROM
+- [`odp`](https://en.wikipedia.org/wiki/OpenDocument) - OpenDocument for presentations
+- [`ods`](https://en.wikipedia.org/wiki/OpenDocument) - OpenDocument for spreadsheets
+- [`odt`](https://en.wikipedia.org/wiki/OpenDocument) - OpenDocument for word processing
 - [`oga`](https://en.wikipedia.org/wiki/Ogg) - Audio file
-- [`spx`](https://en.wikipedia.org/wiki/Ogg) - Audio file
+- [`ogg`](https://en.wikipedia.org/wiki/Ogg) - Audio file
+- [`ogm`](https://en.wikipedia.org/wiki/Ogg) - Audio file
+- [`ogv`](https://en.wikipedia.org/wiki/Ogg) - Audio file
 - [`ogx`](https://en.wikipedia.org/wiki/Ogg) - Audio file
 - [`opus`](https://en.wikipedia.org/wiki/Opus_(audio_format)) - Audio file
-- [`flac`](https://en.wikipedia.org/wiki/FLAC) - Free Lossless Audio Codec
-- [`wav`](https://en.wikipedia.org/wiki/WAV) - Waveform Audio file
-- [`qcp`](https://en.wikipedia.org/wiki/QCP) - Tagged and chunked data
-- [`amr`](https://en.wikipedia.org/wiki/Adaptive_Multi-Rate_audio_codec) - Adaptive Multi-Rate audio codec
+- [`orf`](https://en.wikipedia.org/wiki/ORF_format) - Olympus Raw image file
+- [`otf`](https://en.wikipedia.org/wiki/OpenType) - OpenType font
+- [`pcap`](https://wiki.wireshark.org/Development/LibpcapFileFormat) - Libpcap File Format
 - [`pdf`](https://en.wikipedia.org/wiki/Portable_Document_Format) - Portable Document Format
-- [`epub`](https://en.wikipedia.org/wiki/EPUB) - E-book file
-- [`mobi`](https://en.wikipedia.org/wiki/Mobipocket) - Mobipocket
-- [`exe`](https://en.wikipedia.org/wiki/.exe) - Executable file
-- [`swf`](https://en.wikipedia.org/wiki/SWF) - Adobe Flash Player file
+- [`pgp`](https://en.wikipedia.org/wiki/Pretty_Good_Privacy) - Pretty Good Privacy
+- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics
+- [`pptx`](https://en.wikipedia.org/wiki/Office_Open_XML) - Microsoft Powerpoint
+- [`ps`](https://en.wikipedia.org/wiki/Postscript) - Postscript
+- [`psd`](https://en.wikipedia.org/wiki/Adobe_Photoshop#File_format) - Adobe Photoshop document
+- [`qcp`](https://en.wikipedia.org/wiki/QCP) - Tagged and chunked data
+- [`raf`](https://en.wikipedia.org/wiki/Raw_image_format) - Fujifilm RAW image file
+- [`rar`](https://en.wikipedia.org/wiki/RAR_(file_format)) - Archive file
+- [`rpm`](https://fileinfo.com/extension/rpm) - Red Hat Package Manager file
 - [`rtf`](https://en.wikipedia.org/wiki/Rich_Text_Format) - Rich Text Format
+- [`rw2`](https://en.wikipedia.org/wiki/Raw_image_format) - Panasonic RAW image file
+- [`s3m`](https://wiki.openmpt.org/Manual:_Module_formats#The_ScreamTracker_3_format_.28.s3m.29) - Audio module format: ScreamTracker 3
+- [`shp`](https://en.wikipedia.org/wiki/Shapefile) - Geospatial vector data format
+- [`skp`](https://en.wikipedia.org/wiki/SketchUp) - SketchUp
+- [`spx`](https://en.wikipedia.org/wiki/Ogg) - Audio file
+- [`sqlite`](https://www.sqlite.org/fileformat2.html) - SQLite file
+- [`stl`](https://en.wikipedia.org/wiki/STL_(file_format)) - Standard Tesselated Geometry File Format (ASCII only)
+- [`swf`](https://en.wikipedia.org/wiki/SWF) - Adobe Flash Player file
+- [`tar`](https://en.wikipedia.org/wiki/Tar_(computing)#File_format) - Tarball archive file
+- [`tif`](https://en.wikipedia.org/wiki/Tagged_Image_File_Format) - Tagged Image file
+- [`ttf`](https://en.wikipedia.org/wiki/TrueType) - TrueType font
+- [`vcf`](https://en.wikipedia.org/wiki/VCard) - vCard
+- [`voc`](https://wiki.multimedia.cx/index.php/Creative_Voice) - Creative Voice File
+- [`wasm`](https://en.wikipedia.org/wiki/WebAssembly) - WebAssembly intermediate compiled format
+- [`wav`](https://en.wikipedia.org/wiki/WAV) - Waveform Audio file
+- [`webm`](https://en.wikipedia.org/wiki/WebM) - Web video file
+- [`webp`](https://en.wikipedia.org/wiki/WebP) - Web Picture format
 - [`woff`](https://en.wikipedia.org/wiki/Web_Open_Font_Format) - Web Open Font Format
 - [`woff2`](https://en.wikipedia.org/wiki/Web_Open_Font_Format) - Web Open Font Format
-- [`eot`](https://en.wikipedia.org/wiki/Embedded_OpenType) - Embedded OpenType font
-- [`ttf`](https://en.wikipedia.org/wiki/TrueType) - TrueType font
-- [`otf`](https://en.wikipedia.org/wiki/OpenType) - OpenType font
-- [`ico`](https://en.wikipedia.org/wiki/ICO_(file_format)) - Windows icon file
-- [`flv`](https://en.wikipedia.org/wiki/Flash_Video) - Flash video
-- [`ps`](https://en.wikipedia.org/wiki/Postscript) - Postscript
-- [`xz`](https://en.wikipedia.org/wiki/Xz) - Compressed file
-- [`sqlite`](https://www.sqlite.org/fileformat2.html) - SQLite file
-- [`nes`](https://fileinfo.com/extension/nes) - Nintendo NES ROM
-- [`crx`](https://developer.chrome.com/extensions/crx) - Google Chrome extension
-- [`xpi`](https://en.wikipedia.org/wiki/XPInstall) - XPInstall file
-- [`cab`](https://en.wikipedia.org/wiki/Cabinet_(file_format)) - Cabinet file
-- [`deb`](https://en.wikipedia.org/wiki/Deb_(file_format)) - Debian package
-- [`ar`](https://en.wikipedia.org/wiki/Ar_(Unix)) - Archive file
-- [`rpm`](https://fileinfo.com/extension/rpm) - Red Hat Package Manager file
-- [`Z`](https://fileinfo.com/extension/z) - Unix Compressed File
-- [`lz`](https://en.wikipedia.org/wiki/Lzip) - Arhive file
-- [`cfb`](https://en.wikipedia.org/wiki/Compound_File_Binary_Format) - Compount File Binary Format
-- [`mxf`](https://en.wikipedia.org/wiki/Material_Exchange_Format) - Material Exchange Format
-- [`mts`](https://en.wikipedia.org/wiki/.m2ts) - MPEG-2 Transport Stream, both raw and Blu-ray Disc Audio-Video (BDAV) versions
-- [`wasm`](https://en.wikipedia.org/wiki/WebAssembly) - WebAssembly intermediate compiled format
-- [`blend`](https://wiki.blender.org/index.php/Dev:Source/Architecture/File_Format) - Blender project
-- [`bpg`](https://bellard.org/bpg/) - Better Portable Graphics file
-- [`docx`](https://en.wikipedia.org/wiki/Office_Open_XML) - Microsoft Word
-- [`pptx`](https://en.wikipedia.org/wiki/Office_Open_XML) - Microsoft Powerpoint
-- [`xlsx`](https://en.wikipedia.org/wiki/Office_Open_XML) - Microsoft Excel
-- [`jp2`](https://en.wikipedia.org/wiki/JPEG_2000) - JPEG 2000
-- [`jpm`](https://en.wikipedia.org/wiki/JPEG_2000) - JPEG 2000
-- [`jpx`](https://en.wikipedia.org/wiki/JPEG_2000) - JPEG 2000
-- [`mj2`](https://en.wikipedia.org/wiki/Motion_JPEG_2000) - Motion JPEG 2000
-- [`aif`](https://en.wikipedia.org/wiki/Audio_Interchange_File_Format) - Audio Interchange file
-- [`odt`](https://en.wikipedia.org/wiki/OpenDocument) - OpenDocument for word processing
-- [`ods`](https://en.wikipedia.org/wiki/OpenDocument) - OpenDocument for spreadsheets
-- [`odp`](https://en.wikipedia.org/wiki/OpenDocument) - OpenDocument for presentations
-- [`xml`](https://en.wikipedia.org/wiki/XML) - eXtensible Markup Language
-- [`heic`](https://nokiatech.github.io/heif/technical.html) - High Efficiency Image File Format
-- [`cur`](https://en.wikipedia.org/wiki/ICO_(file_format)) - Icon file
-- [`ktx`](https://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/) - OpenGL and OpenGL ES textures
-- [`ape`](https://en.wikipedia.org/wiki/Monkey%27s_Audio) - Monkey's Audio
 - [`wv`](https://en.wikipedia.org/wiki/WavPack) - WavPack
-- [`asf`](https://en.wikipedia.org/wiki/Advanced_Systems_Format) - Advanced Systems Format
-- [`dcm`](https://en.wikipedia.org/wiki/DICOM#Data_format) - DICOM Image File
-- [`mpc`](https://en.wikipedia.org/wiki/Musepack) - Musepack (SV7 & SV8)
-- [`ics`](https://en.wikipedia.org/wiki/ICalendar#Data_format) - iCalendar
-- [`vcf`](https://en.wikipedia.org/wiki/VCard) - vCard
-- [`glb`](https://github.com/KhronosGroup/glTF) - GL Transmission Format
-- [`pcap`](https://wiki.wireshark.org/Development/LibpcapFileFormat) - Libpcap File Format
-- [`dsf`](https://dsd-guide.com/sites/default/files/white-papers/DSFFileFormatSpec_E.pdf) - Sony DSD Stream File (DSF)
-- [`lnk`](https://en.wikipedia.org/wiki/Shortcut_%28computing%29#Microsoft_Windows) - Microsoft Windows file shortcut
-- [`alias`](https://en.wikipedia.org/wiki/Alias_%28Mac_OS%29) - macOS Alias file
-- [`voc`](https://wiki.multimedia.cx/index.php/Creative_Voice) - Creative Voice File
-- [`ac3`](https://www.atsc.org/standard/a522012-digital-audio-compression-ac-3-e-ac-3-standard-12172012/) - ATSC A/52 Audio File
-- [`3gp`](https://en.wikipedia.org/wiki/3GP_and_3G2#3GP) - Multimedia container format defined by the Third Generation Partnership Project (3GPP) for 3G UMTS multimedia services
-- [`3g2`](https://en.wikipedia.org/wiki/3GP_and_3G2#3G2) - Multimedia container format defined by the 3GPP2 for 3G CDMA2000 multimedia services
-- [`m4v`](https://en.wikipedia.org/wiki/M4V) -  MPEG-4 Visual bitstreams
-- [`m4p`](https://en.wikipedia.org/wiki/MPEG-4_Part_14#Filename_extensions) - MPEG-4 files with audio streams encrypted by FairPlay Digital Rights Management as were sold through the iTunes Store
-- [`m4a`](https://en.wikipedia.org/wiki/M4A) - Audio-only MPEG-4 files
-- [`m4b`](https://en.wikipedia.org/wiki/M4B) - Audiobook and podcast MPEG-4 files, which also contain metadata including chapter markers, images, and hyperlinks
-- [`f4v`](https://en.wikipedia.org/wiki/Flash_Video) - ISO base media file format used by Adobe Flash Player
-- [`f4p`](https://en.wikipedia.org/wiki/Flash_Video) - ISO base media file format protected by Adobe Access DRM used by Adobe Flash Player
-- [`f4a`](https://en.wikipedia.org/wiki/Flash_Video) - Audio-only ISO base media file format used by Adobe Flash Player
-- [`f4b`](https://en.wikipedia.org/wiki/Flash_Video) - Audiobook and podcast ISO base media file format used by Adobe Flash Player
-- [`mie`](https://en.wikipedia.org/wiki/Sidecar_file) - Dedicated meta information format which supports storage of binary as well as textual meta information
-- [`shp`](https://en.wikipedia.org/wiki/Shapefile) - Geospatial vector data format
-- [`arrow`](https://arrow.apache.org) - Columnar format for tables of data
-- [`aac`](https://en.wikipedia.org/wiki/Advanced_Audio_Coding) - Advanced Audio Coding
-- [`it`](https://wiki.openmpt.org/Manual:_Module_formats#The_Impulse_Tracker_format_.28.it.29) - Audio module format: Impulse Tracker
-- [`s3m`](https://wiki.openmpt.org/Manual:_Module_formats#The_ScreamTracker_3_format_.28.s3m.29) - Audio module format: ScreamTracker 3
+- [`xcf`](https://en.wikipedia.org/wiki/XCF_(file_format)) - eXperimental Computing Facility
+- [`xlsx`](https://en.wikipedia.org/wiki/Office_Open_XML) - Microsoft Excel
 - [`xm`](https://wiki.openmpt.org/Manual:_Module_formats#The_FastTracker_2_format_.28.xm.29) - Audio module format: FastTracker 2
-- [`ai`](https://en.wikipedia.org/wiki/Adobe_Illustrator_Artwork) - Adobe Illustrator Artwork
-- [`skp`](https://en.wikipedia.org/wiki/SketchUp) - SketchUp
-- [`avif`](https://en.wikipedia.org/wiki/AV1#AV1_Image_File_Format_(AVIF)) - AV1 Image File Format
-- [`eps`](https://en.wikipedia.org/wiki/Encapsulated_PostScript) - Encapsulated PostScript
-- [`lzh`](https://en.wikipedia.org/wiki/LHA_(file_format)) - LZH archive
-- [`pgp`](https://en.wikipedia.org/wiki/Pretty_Good_Privacy) - Pretty Good Privacy
-- [`asar`](https://github.com/electron/asar#format) - Archive format primarily used to enclose Electron applications
-- [`stl`](https://en.wikipedia.org/wiki/STL_(file_format)) - Standard Tesselated Geometry File Format (ASCII only)
-- [`chm`](https://en.wikipedia.org/wiki/Microsoft_Compiled_HTML_Help) - Microsoft Compiled HTML Help
-- [`3mf`](https://en.wikipedia.org/wiki/3D_Manufacturing_Format) - 3D Manufacturing Format
-- [`jxl`](https://en.wikipedia.org/wiki/JPEG_XL) - JPEG XL image format
+- [`xml`](https://en.wikipedia.org/wiki/XML) - eXtensible Markup Language
+- [`xpi`](https://en.wikipedia.org/wiki/XPInstall) - XPInstall file
+- [`xz`](https://en.wikipedia.org/wiki/Xz) - Compressed file
+- [`zip`](https://en.wikipedia.org/wiki/Zip_(file_format)) - Archive file
+- [`zst`](https://en.wikipedia.org/wiki/Zstandard) - Archive file
 
 *Pull requests are welcome for additional commonly used file types.*
 


### PR DESCRIPTION
Hi, the list of the supported file in the readme.md is not sorted. Today I have discovered this library and was trying to figure out if it supports pdfs and some other format it was hard to find them in the list. It's a small change but I think it could help the people in my position. If there is a particular reason for the current order you may just ignore this pr.