### PR TITLE
Update strtok3 to 7.0.0-alpha.7 & token-types to 5.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,8 +196,8 @@
 	],
 	"dependencies": {
 		"readable-web-to-node-stream": "^3.0.2",
-		"strtok3": "^7.0.0-alpha.5",
-		"token-types": "^5.0.0-alpha.0"
+		"strtok3": "^7.0.0-alpha.7",
+		"token-types": "^5.0.0-alpha.1"
 	},
 	"devDependencies": {
 		"@tokenizer/token": "^0.3.0",


### PR DESCRIPTION
Should prevent "Concurrent read operation" error to be thrown, while reading from a stream.

Updates:
- [strtok3 to 7.0.0-alpha.7](https://github.com/Borewit/strtok3/releases/tag/v7.0.0-alpha.7), which update [peek-readable to v5.0.0-alpha.5](https://github.com/Borewit/peek-readable/releases/tag/v5.0.0-alpha.5), fixing #508
- [token-types to 5.0.0-alpha.1](https://github.com/Borewit/token-types/releases/tag/v5.0.0-alpha.1), fixing dependency pollution

Fixes: sindresorhus/file-type#508

