### PR TITLE
Fix error: Cannot find module 'strtok3/core'

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,6 +1,6 @@
 import {Buffer} from 'node:buffer';
 import * as Token from 'token-types';
-import * as strtok3 from 'strtok3/core';
+import * as strtok3 from 'strtok3/lib/core';
 import {
 	stringToBytes,
 	tarHeaderChecksumMatches,


### PR DESCRIPTION
Set the correct path of the core file of the strtok3 package
https://github.com/Borewit/strtok3/blob/v7.0.0-alpha.7/lib/core.ts
