### PR TITLE
Improve signature ordering detection requirements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@ If you're adding support for a new file type, please follow the below steps:
 - Add the file's MIME type to the `types` array in `supported.js`.
 - Add the file type detection logic to the `core.js` file
 - Respect the sequence:
-  - Signature with shorter sample size (counted from offset 0 until the last required byte position) will be executed first
-  - Only the initial determination for the file type counts for the sequence
-  - Existing signatures requiring same sample length (same _signature group_) will be tested prior to your new detections. Yours will be last. (rational: common formats first)
+	- Signature with shorter sample size (counted from offset 0 until the last required byte position) will be executed first.
+	- Only the initial determination for the file type counts for the sequence.
+	- Existing signatures requiring same sample length (same *signature group*) will be tested prior to your new detections. Yours will be last. (rational: common formats first).
 - Add the file extension to the `FileType` type in `core.d.ts`.
 - Add the file's MIME type to the `MimeType` type in `core.d.ts`.
 - Add the file extension to the `Supported file types` section in the readme, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,11 @@ If you're adding support for a new file type, please follow the below steps:
 - Add a fixture file named `fixture.<extension>` to the `fixture` directory.
 - Add the file extension to the `extensions` array in `supported.js`.
 - Add the file's MIME type to the `types` array in `supported.js`.
-- Add the file type detection logic to the `core.js` file.
+- Add the file type detection logic to the `core.js` file
+- Respect the sequence:
+  - Signature with shorter sample size (counted from offset 0 until the last required byte position) will be executed first
+  - Only the initial determination for the file type counts for the sequence
+  - Existing signatures requiring same sample length (same _signature group_) will be tested prior to your new detections. Yours will be last. (rational: common formats first)
 - Add the file extension to the `FileType` type in `core.d.ts`.
 - Add the file's MIME type to the `MimeType` type in `core.d.ts`.
 - Add the file extension to the `Supported file types` section in the readme, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```

--- a/core.js
+++ b/core.js
@@ -151,6 +151,13 @@ class FileTypeParser {
 
 		// -- 3-byte signatures --
 
+		if (this.check([0x47, 0x49, 0x46])) {
+			return {
+				ext: 'gif',
+				mime: 'image/gif',
+			};
+		}
+
 		if (this.check([0xFF, 0xD8, 0xFF])) {
 			return {
 				ext: 'jpg',
@@ -213,20 +220,6 @@ class FileTypeParser {
 		}
 
 		// -- 4-byte signatures --
-
-		if (this.check([0x7F, 0x45, 0x4C, 0x46])) {
-			return {
-				ext: 'elf',
-				mime: 'application/x-elf',
-			};
-		}
-
-		if (this.check([0x47, 0x49, 0x46])) {
-			return {
-				ext: 'gif',
-				mime: 'image/gif',
-			};
-		}
 
 		if (this.checkString('FLIF')) {
 			return {
@@ -795,6 +788,13 @@ class FileTypeParser {
 			return {
 				ext: 'zst',
 				mime: 'application/zstd',
+			};
+		}
+
+		if (this.check([0x7F, 0x45, 0x4C, 0x46])) {
+			return {
+				ext: 'elf',
+				mime: 'application/x-elf',
 			};
 		}
 


### PR DESCRIPTION
Related to [comment: "_... this one need to move to the 3-byte signature_"](https://github.com/sindresorhus/file-type/pull/514/files/09d4fc0aa8089addbc9a2fb78ab18069412047b8#r775133360).

Changes:
1. Update PR guidelines
2. Move `.gif` detection from 4 to 3 byte signature group
3. Make ELF detection last test in 4 byte signature group rather then the last one
