### PR TITLE
Update strtok3 to ^7.0.0-alpha.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
 	],
 	"dependencies": {
 		"readable-web-to-node-stream": "^3.0.2",
-		"strtok3": "^7.0.0-alpha.7",
+		"strtok3": "^7.0.0-alpha.9",
 		"token-types": "^5.0.0-alpha.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Resolve problem importing './types' in [strtok3](https://github.com/Borewit/strtok3) dependency, see Borewit/strtok3#764
