### PR TITLE
Fix import path ITokenizer

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -1,5 +1,5 @@
 import {Readable as ReadableStream} from 'node:stream';
-import {ITokenizer} from 'strtok3/lib/core';
+import {ITokenizer} from 'strtok3';
 
 export type FileExtension =
 	| 'jpg'


### PR DESCRIPTION
I think the import path 

```js
import {ITokenizer} from 'strtok3';
```

as the export of strtok3 is:
```json
"exports": {
    ".": {
      "node": "./lib/index.js",
      "default": "./lib/core.js"
    }
```

where both `index.js` & `core.js` export `ITokenizer`    
