### PR TITLE
Update development dependencies: ava, tsd, xo

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -1,4 +1,4 @@
-import {FileTypeResult} from './core.js';
+import type {FileTypeResult} from './core.js';
 
 /**
 Detect the file type of a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
@@ -42,7 +42,7 @@ export {
 	fileTypeFromBuffer,
 	supportedExtensions,
 	supportedMimeTypes,
-	FileTypeResult,
-	FileExtension,
-	MimeType,
+	type FileTypeResult,
+	type FileExtension,
+	type MimeType,
 } from './core.js';

--- a/core.d.ts
+++ b/core.d.ts
@@ -1,5 +1,5 @@
-import {Readable as ReadableStream} from 'node:stream';
-import {ITokenizer} from 'strtok3';
+import type {Readable as ReadableStream} from 'node:stream';
+import type {ITokenizer} from 'strtok3';
 
 export type FileExtension =
 	| 'jpg'
@@ -278,7 +278,7 @@ export type MimeType =
 	| 'image/jxl'
 	| 'application/zstd';
 
-export interface FileTypeResult {
+export type FileTypeResult = {
 	/**
 	One of the supported [file types](https://github.com/sindresorhus/file-type#supported-file-types).
 	*/
@@ -288,7 +288,7 @@ export interface FileTypeResult {
 	The detected [MIME type](https://en.wikipedia.org/wiki/Internet_media_type).
 	*/
 	readonly mime: MimeType;
-}
+};
 
 export type ReadableStreamWithFileType = ReadableStream & {
 	readonly fileType?: FileTypeResult;
@@ -354,14 +354,14 @@ Supported MIME types.
 */
 export const supportedMimeTypes: ReadonlySet<MimeType>;
 
-export interface StreamOptions {
+export type StreamOptions = {
 	/**
 	The default sample size in bytes.
 
 	@default 4100
 	*/
 	readonly sampleSize?: number;
-}
+};
 
 /**
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.

--- a/core.js
+++ b/core.js
@@ -1484,7 +1484,7 @@ class FileTypeParser {
 
 			await this.tokenizer.ignore(ifdOffset);
 			const fileType = await this.readTiffIFD(false);
-			return fileType ? fileType : {
+			return fileType ?? {
 				ext: 'tif',
 				mime: 'image/tiff',
 			};

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
-import {Readable as ReadableStream} from 'node:stream';
-import {FileTypeResult} from './core.js';
+import type {FileTypeResult} from './core.js';
 
 /**
 Detect the file type of a file path.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,9 +1,9 @@
 import {Buffer} from 'node:buffer';
-import fs from 'node:fs';
+import {createReadStream} from 'node:fs';
 import {expectType} from 'tsd';
 import {
 	fileTypeFromBlob,
-	FileTypeResult as FileTypeResultBrowser,
+	type FileTypeResult as FileTypeResultBrowser,
 } from './browser.js';
 import {
 	fileTypeFromBuffer,
@@ -12,10 +12,10 @@ import {
 	fileTypeStream,
 	supportedExtensions,
 	supportedMimeTypes,
-	FileTypeResult,
-	ReadableStreamWithFileType,
-	FileExtension,
-	MimeType,
+	type FileTypeResult,
+	type ReadableStreamWithFileType,
+	type FileExtension,
+	type MimeType,
 } from './index.js';
 
 expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(Buffer.from([0xFF, 0xD8, 0xFF])));
@@ -41,7 +41,7 @@ expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuff
 })();
 
 (async () => {
-	const stream = fs.createReadStream('myFile');
+	const stream = createReadStream('myFile');
 
 	expectType<FileTypeResult | undefined>(await fileTypeFromStream(stream));
 
@@ -56,7 +56,7 @@ expectType<ReadonlySet<FileExtension>>(supportedExtensions);
 
 expectType<ReadonlySet<MimeType>>(supportedMimeTypes);
 
-const readableStream = fs.createReadStream('file.png');
+const readableStream = createReadStream('file.png');
 const streamWithFileType = fileTypeStream(readableStream);
 expectType<Promise<ReadableStreamWithFileType>>(streamWithFileType);
 (async () => {

--- a/package.json
+++ b/package.json
@@ -203,11 +203,11 @@
 	"devDependencies": {
 		"@tokenizer/token": "^0.3.0",
 		"@types/node": "^18.7.13",
-		"ava": "^4.3.1",
+		"ava": "^5.1.0",
 		"commonmark": "^0.30.0",
 		"noop-stream": "^1.0.0",
-		"tsd": "^0.22.0",
-		"xo": "^0.51.0"
+		"tsd": "^0.25.0",
+		"xo": "^0.53.1"
 	},
 	"xo": {
 		"envs": [
@@ -219,7 +219,9 @@
 			"no-await-in-loop": "warn",
 			"no-bitwise": "off",
 			"@typescript-eslint/no-unsafe-assignment": "off",
-			"unicorn/text-encoding-identifier-case": "off"
+			"unicorn/text-encoding-identifier-case": "off",
+		    "unicorn/switch-case-braces": "off",
+		    "unicorn/prefer-top-level-await": "off"
 		}
 	},
 	"ava": {


### PR DESCRIPTION
1. Update development dependencies (resolving multiple vulnerability warnings): 
   - ava 4.3.1 to [5.1.0](https://github.com/avajs/ava/releases/tag/v5.1.0)
   - tsd 0.22.0 to [0.25.0](https://github.com/SamVerschueren/tsd/releases/tag/v0.25.0)
   -  xo 0.51.0 to [0.53.1](https://github.com/xojs/xo/releases/tag/v0.53.1)
2. Updated code style to comply with tsd.
3. Excluded some new [tsd](https://github.com/SamVerschueren/tsd) default rules in `package.json`.
4. Explicit import of `createReadStream` function from `node:fs`
5. Removed unused import from `index.d.ts`
