### PR TITLE
Handle very small pdf's

### DIFF
--- a/core.js
+++ b/core.js
@@ -611,17 +611,24 @@ class FileTypeParser {
 		}
 
 		if (this.checkString('%PDF')) {
-			await tokenizer.ignore(1350);
-			const maxBufferSize = 10 * 1024 * 1024;
-			const buffer = Buffer.alloc(Math.min(maxBufferSize, tokenizer.fileInfo.size));
-			await tokenizer.readBuffer(buffer, {mayBeLess: true});
+			try {
+				await tokenizer.ignore(1350);
+				const maxBufferSize = 10 * 1024 * 1024;
+				const buffer = Buffer.alloc(Math.min(maxBufferSize, tokenizer.fileInfo.size));
+				await tokenizer.readBuffer(buffer, {mayBeLess: true});
 
-			// Check if this is an Adobe Illustrator file
-			if (buffer.includes(Buffer.from('AIPrivateData'))) {
-				return {
-					ext: 'ai',
-					mime: 'application/postscript',
-				};
+				// Check if this is an Adobe Illustrator file
+				if (buffer.includes(Buffer.from('AIPrivateData'))) {
+					return {
+						ext: 'ai',
+						mime: 'application/postscript',
+					};
+				}
+			} catch (error) {
+				// Swallow end of stream error if file is too small for the Adobe AI check
+				if (!(error instanceof strtok3.EndOfStreamError)) {
+					throw error;
+				}
 			}
 
 			// Assume this is just a normal PDF

--- a/fixture/fixture-minimal.pdf
+++ b/fixture/fixture-minimal.pdf
@@ -1,0 +1,58 @@
+%PDF-1.1
+%¥±ë
+
+1 0 obj
+  << /Type /Catalog
+     /Pages 2 0 R
+  >>
+endobj
+
+2 0 obj
+  << /Type /Pages
+     /Kids [3 0 R]
+     /Count 1
+     /MediaBox [0 0 300 144]
+  >>
+endobj
+
+3 0 obj
+  <<  /Type /Page
+      /Parent 2 0 R
+      /Resources
+       << /Font
+           << /F1
+               << /Type /Font
+                  /Subtype /Type1
+                  /BaseFont /Times-Roman
+               >>
+           >>
+       >>
+      /Contents 4 0 R
+  >>
+endobj
+
+4 0 obj
+  << /Length 55 >>
+stream
+  BT
+    /F1 18 Tf
+    0 0 Td
+    (Hello World) Tj
+  ET
+endstream
+endobj
+
+xref
+0 5
+0000000000 65535 f 
+0000000018 00000 n 
+0000000077 00000 n 
+0000000178 00000 n 
+0000000457 00000 n 
+trailer
+  <<  /Root 1 0 R
+      /Size 5
+  >>
+startxref
+565
+%%EOF

--- a/test.js
+++ b/test.js
@@ -219,6 +219,7 @@ const names = {
 		'fixture-smallest', // PDF saved from Adobe Illustrator, using the preset "smallest PDF"
 		'fixture-fast-web', // PDF saved from Adobe Illustrator, using the default "[Illustrator Default"] preset, but enabling "Optimize for Fast Web View"
 		'fixture-printed', // PDF printed from Adobe Illustrator, but with a PDF printer.
+		'fixture-minimal', // PDF written to be as small as the spec allows
 	],
 	webm: [
 		'fixture-null', // EBML DocType with trailing null character


### PR DESCRIPTION
Handle tiny pdf's, and add a test pdf < 1350 bytes (the test pdf is MIT licensed and from https://brendanzagaeski.appspot.com/0004.html)

just fyi generating an empty pdf from google drive results in a pdf of similar size (~700 bytes)

resolves https://github.com/sindresorhus/file-type/issues/579