### PR TITLE
Support for reading from Blob in Node.js

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -18,28 +18,9 @@ console.log(fileType);
 */
 export declare function fileTypeFromStream(stream: ReadableStream): Promise<FileTypeResult | undefined>;
 
-/**
-Detect the file type of a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
-
-__Note:__ This method is only available in the browser.
-
-@example
-```
-import {fileTypeFromBlob} from 'file-type';
-
-const blob = new Blob(['<?xml version="1.0" encoding="ISO-8859-1" ?>'], {
-	type: 'plain/text',
-	endings: 'native'
-});
-
-console.log(await fileTypeFromBlob(blob));
-//=> {ext: 'txt', mime: 'plain/text'}
-```
-*/
-export declare function fileTypeFromBlob(blob: Blob): Promise<FileTypeResult | undefined>;
-
 export {
 	fileTypeFromBuffer,
+	fileTypeFromBlob,
 	supportedExtensions,
 	supportedMimeTypes,
 	type FileTypeResult,

--- a/browser.js
+++ b/browser.js
@@ -1,47 +1,11 @@
-import {Buffer} from 'node:buffer';
 import {ReadableWebToNodeStream} from 'readable-web-to-node-stream';
-import {fileTypeFromBuffer, fileTypeFromStream as coreFileTypeFromStream} from './core.js';
-
-/**
-Convert Blobs to ArrayBuffer.
-
-@param {Blob} blob - Web API Blob.
-@returns {Promise<ArrayBuffer>}
-*/
-function blobToArrayBuffer(blob) {
-	if (blob.arrayBuffer) {
-		return blob.arrayBuffer();
-	}
-
-	// TODO: Remove when stop supporting older environments
-	return new Promise((resolve, reject) => {
-		const fileReader = new FileReader();
-		fileReader.addEventListener('loadend', event => {
-			resolve(event.target.result);
-		});
-
-		fileReader.addEventListener('error', event => {
-			reject(new Error(event.message));
-		});
-
-		fileReader.addEventListener('abort', event => {
-			reject(new Error(event.type));
-		});
-
-		fileReader.readAsArrayBuffer(blob);
-	});
-}
+import {fileTypeFromStream as coreFileTypeFromStream} from './core.js';
 
 export async function fileTypeFromStream(stream) {
 	const readableWebToNodeStream = new ReadableWebToNodeStream(stream);
 	const fileType = await coreFileTypeFromStream(readableWebToNodeStream);
 	await readableWebToNodeStream.close();
 	return fileType;
-}
-
-export async function fileTypeFromBlob(blob) {
-	const buffer = await blobToArrayBuffer(blob);
-	return fileTypeFromBuffer(Buffer.from(buffer));
 }
 
 export {

--- a/core.d.ts
+++ b/core.d.ts
@@ -401,3 +401,21 @@ if (stream2.fileType?.mime === 'image/jpeg') {
 ```
 */
 export function fileTypeStream(readableStream: ReadableStream, options?: StreamOptions): Promise<ReadableStreamWithFileType>;
+
+/**
+Detect the file type of a [`Blob`](https://nodejs.org/api/buffer.html#class-blob).
+
+@example
+```
+import {fileTypeFromBlob} from 'file-type';
+
+const blob = new Blob(['<?xml version="1.0" encoding="ISO-8859-1" ?>'], {
+	type: 'plain/text',
+	endings: 'native'
+});
+
+console.log(await fileTypeFromBlob(blob));
+//=> {ext: 'txt', mime: 'plain/text'}
+```
+ */
+export declare function fileTypeFromBlob(blob: Blob): Promise<FileTypeResult | undefined>;

--- a/core.js
+++ b/core.js
@@ -33,6 +33,11 @@ export async function fileTypeFromBuffer(input) {
 	return fileTypeFromTokenizer(strtok3.fromBuffer(buffer));
 }
 
+export async function fileTypeFromBlob(blob) {
+	const buffer = await blob.arrayBuffer();
+	return fileTypeFromBuffer(new Uint8Array(buffer));
+}
+
 function _check(buffer, headers, options) {
 	options = {
 		offset: 0,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,10 +2,10 @@ import {Buffer} from 'node:buffer';
 import {createReadStream} from 'node:fs';
 import {expectType} from 'tsd';
 import {
-	fileTypeFromBlob,
 	type FileTypeResult as FileTypeResultBrowser,
 } from './browser.js';
 import {
+	fileTypeFromBlob,
 	fileTypeFromBuffer,
 	fileTypeFromFile,
 	fileTypeFromStream,

--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,6 @@ A readable stream representing file data.
 
 Detect the file type of a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
 
-**Note:** This method is only available in the browser.
-
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
 Returns a `Promise` for an object with the detected file type and MIME type:

--- a/test.js
+++ b/test.js
@@ -11,9 +11,10 @@ import {
 	fileTypeFromBuffer,
 	fileTypeFromStream,
 	fileTypeFromFile,
+	fileTypeFromBlob,
 	fileTypeStream,
 	supportedExtensions,
-	supportedMimeTypes, fileTypeFromBlob,
+	supportedMimeTypes,
 } from './index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import {Buffer} from 'node:buffer';
+import {Buffer, Blob} from 'node:buffer';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import fs from 'node:fs';
@@ -13,7 +13,7 @@ import {
 	fileTypeFromFile,
 	fileTypeStream,
 	supportedExtensions,
-	supportedMimeTypes,
+	supportedMimeTypes, fileTypeFromBlob,
 } from './index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -262,6 +262,13 @@ async function checkBufferLike(t, type, bufferLike) {
 	t.is(typeof mime, 'string');
 }
 
+async function checkBlobLike(t, type, bufferLike) {
+	const blob = new Blob([bufferLike]);
+	const {ext, mime} = await fileTypeFromBlob(blob) ?? {};
+	t.is(ext, type);
+	t.is(typeof mime, 'string');
+}
+
 async function checkFile(t, type, filePath) {
 	const {ext, mime} = await fileTypeFromFile(filePath) ?? {};
 	t.is(ext, type);
@@ -281,6 +288,14 @@ async function testFromBuffer(t, ext, name) {
 	await checkBufferLike(t, ext, chunk);
 	await checkBufferLike(t, ext, new Uint8Array(chunk));
 	await checkBufferLike(t, ext, chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength));
+}
+
+async function testFromBlob(t, ext, name) {
+	const fixtureName = `${(name ?? 'fixture')}.${ext}`;
+
+	const file = path.join(__dirname, 'fixture', fixtureName);
+	const chunk = fs.readFileSync(file);
+	await checkBlobLike(t, ext, chunk);
 }
 
 async function testFalsePositive(t, ext, name) {
@@ -334,6 +349,7 @@ for (const type of types) {
 
 			_test(`${name}.${type} ${i++} .fileTypeFromFile() method - same fileType`, testFromFile, type, name);
 			_test(`${name}.${type} ${i++} .fileTypeFromBuffer() method - same fileType`, testFromBuffer, type, name);
+			_test(`${name}.${type} ${i++} .fileTypeFromBlob() method - same fileType`, testFromBlob, type, name);
 			_test(`${name}.${type} ${i++} .fileTypeFromStream() method - same fileType`, testFileFromStream, type, name);
 			test(`${name}.${type} ${i++} .fileTypeStream() - identical streams`, testStream, type, name);
 		}


### PR DESCRIPTION
Support for reading from [Blob](https://nodejs.org/api/buffer.html#class-blob) in Node.js context.

Resolves: #581

First merge: 
- #587
