### PR TITLE
Use mimetype `audio/wav` for .wav files

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -192,7 +192,7 @@ export type MimeType =
 	| 'video/webm'
 	| 'video/quicktime'
 	| 'video/vnd.avi'
-	| 'audio/vnd.wave'
+	| 'audio/wav'
 	| 'audio/qcelp'
 	| 'audio/x-ms-asf'
 	| 'video/x-ms-asf'

--- a/core.js
+++ b/core.js
@@ -835,7 +835,7 @@ export class FileTypeParser {
 			if (this.check([0x57, 0x41, 0x56, 0x45], {offset: 8})) {
 				return {
 					ext: 'wav',
-					mime: 'audio/vnd.wave',
+					mime: 'audio/wav',
 				};
 			}
 

--- a/supported.js
+++ b/supported.js
@@ -189,7 +189,7 @@ export const mimeTypes = [
 	'video/webm',
 	'video/quicktime',
 	'video/vnd.avi',
-	'audio/vnd.wave',
+	'audio/wav',
 	'audio/qcelp',
 	'audio/x-ms-asf',
 	'video/x-ms-asf',


### PR DESCRIPTION
Use mimetype `audio/wav` for `.wav` files instead of unsupported `audio/vnd.wave`

As pointed out in this [comment](https://github.com/sindresorhus/file-type/pull/150#issuecomment-1869471110), the correct mimetype supported by all major browsers (chrome, firefox, safari) is `audio/wav` and not `audio/vnd.wave`.

I made a simple html page to test the behaviour, which also include a test for `.avi` files. The test show that I didn't find any supported mimetype for `.avi` files, so I will not do a PR for that.

[test-mimetype.zip](https://github.com/sindresorhus/file-type/files/13798200/test-mimetype.zip)
