### PR TITLE
Improve Blob, file, and stream method documentation

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -341,11 +341,11 @@ If file access is available, it is recommended to use `.fromFile()` instead.
 export function fileTypeFromBuffer(buffer: Uint8Array | ArrayBuffer): Promise<FileTypeResult | undefined>;
 
 /**
-Detect the file type of a [Web ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+Detect the file type of a [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
-@param stream A [Web ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
+@param stream A [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
 @returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
  */
 export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array>): Promise<FileTypeResult | undefined>;

--- a/core.d.ts
+++ b/core.d.ts
@@ -347,7 +347,7 @@ The file type is detected by checking the [magic number](https://en.wikipedia.or
 
 @param stream A [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
 @returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
- */
+*/
 export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array>): Promise<FileTypeResult | undefined>;
 
 /**

--- a/core.d.ts
+++ b/core.d.ts
@@ -341,13 +341,13 @@ If file access is available, it is recommended to use `.fromFile()` instead.
 export function fileTypeFromBuffer(buffer: Uint8Array | ArrayBuffer): Promise<FileTypeResult | undefined>;
 
 /**
-Detect the file type of a Node.js [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).
+Detect the file type of a [Web ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
-@param stream - A Node.js Readable stream or Web API Readable Stream representing file data. The Web Readable stream **must be a byte stream**.
-@returns The detected file type, or `undefined` when there is no match.
-*/
+@param stream A [Web ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
+@returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
+ */
 export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array>): Promise<FileTypeResult | undefined>;
 
 /**

--- a/core.d.ts
+++ b/core.d.ts
@@ -341,7 +341,7 @@ If file access is available, it is recommended to use `.fromFile()` instead.
 export function fileTypeFromBuffer(buffer: Uint8Array | ArrayBuffer): Promise<FileTypeResult | undefined>;
 
 /**
-Detect the file type of a [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 

--- a/core.d.ts
+++ b/core.d.ts
@@ -345,7 +345,7 @@ Detect the file type of a [Web `ReadableStream`](https://developer.mozilla.org/e
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
-@param stream A [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
+@param stream - A [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
 @returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
 */
 export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array>): Promise<FileTypeResult | undefined>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ Extending `FileTypeParser` with Node.js engine specific functions.
 */
 export declare class NodeFileTypeParser extends FileTypeParser {
 	/**
-	@param stream - Node.js `stream.Readable` or Web `ReadableStream`.
+	@param stream - Node.js `stream.Readable` or web `ReadableStream`.
 	*/
 	fromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream): Promise<FileTypeResult | undefined>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,9 @@ export type ReadableStreamWithFileType = NodeReadableStream & {
 	readonly fileType?: FileTypeResult;
 };
 
+/**
+ * Extending `FileTypeParser` with Node.js engine specific functions
+ */
 export declare class NodeFileTypeParser extends FileTypeParser {
 	/**
 	@param stream - Node.js `stream.Readable` or Web API `ReadableStream`.
@@ -28,11 +31,25 @@ export declare class NodeFileTypeParser extends FileTypeParser {
 Detect the file type of a file path.
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the file.
+This is for Node.js only.
+To read from a [File](https://developer.mozilla.org/docs/Web/API/File), please see [fileTypeFromBlob(blob)](#filetypefromblobblob).
+
+The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
 @returns The detected file type and MIME type or `undefined` when there is no match.
 */
 export function fileTypeFromFile(filePath: string, options?: {customDetectors?: Iterable<Detector>}): Promise<FileTypeResult | undefined>;
 
+/**
+Detect the file type of a [Web ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+If the engine is Node.js, this may also be a [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).
+Direct support for Node.js streams will be dropped in the future, when Node.js streams can be converted to Web streams (see [toWeb()](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
+
+The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
+
+@param stream A [Web ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) streaming a file to examine.
+@returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
+ */
 export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream): Promise<FileTypeResult | undefined>;
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ export function fileTypeFromFile(filePath: string, options?: {customDetectors?: 
 
 /**
 Detect the file type of a [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
-If the engine is Node.js, this may also be a [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).
+If the engine is Node.js, this may also be a [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable).
 Direct support for Node.js streams will be dropped in the future, when Node.js streams can be converted to Web streams (see [toWeb()](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,8 +31,10 @@ export declare class NodeFileTypeParser extends FileTypeParser {
 Detect the file type of a file path.
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the file.
+
 This is for Node.js only.
-To read from a [File](https://developer.mozilla.org/docs/Web/API/File), please see [fileTypeFromBlob(blob)](#filetypefromblobblob).
+
+To read from a [`File`](https://developer.mozilla.org/docs/Web/API/File), see `fileTypeFromBlob()`.
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,15 +43,17 @@ The file type is detected by checking the [magic number](https://en.wikipedia.or
 export function fileTypeFromFile(filePath: string, options?: {customDetectors?: Iterable<Detector>}): Promise<FileTypeResult | undefined>;
 
 /**
-Detect the file type of a [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+
 If the engine is Node.js, this may also be a [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable).
-Direct support for Node.js streams will be dropped in the future, when Node.js streams can be converted to Web streams (see [toWeb()](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
+
+Direct support for Node.js streams will be dropped in the future, when Node.js streams can be converted to Web streams (see [`toWeb()`](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
-@param stream A [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) streaming a file to examine.
+@param stream - A [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable) streaming a file to examine.
 @returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
- */
+*/
 export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream): Promise<FileTypeResult | undefined>;
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ Extending `FileTypeParser` with Node.js engine specific functions.
 */
 export declare class NodeFileTypeParser extends FileTypeParser {
 	/**
-	@param stream - Node.js `stream.Readable` or Web API `ReadableStream`.
+	@param stream - Node.js `stream.Readable` or Web `ReadableStream`.
 	*/
 	fromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream): Promise<FileTypeResult | undefined>;
 
@@ -41,13 +41,13 @@ The file type is detected by checking the [magic number](https://en.wikipedia.or
 export function fileTypeFromFile(filePath: string, options?: {customDetectors?: Iterable<Detector>}): Promise<FileTypeResult | undefined>;
 
 /**
-Detect the file type of a [Web ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+Detect the file type of a [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 If the engine is Node.js, this may also be a [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).
 Direct support for Node.js streams will be dropped in the future, when Node.js streams can be converted to Web streams (see [toWeb()](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
-@param stream A [Web ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) streaming a file to examine.
+@param stream A [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) streaming a file to examine.
 @returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
  */
 export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream): Promise<FileTypeResult | undefined>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,8 +11,8 @@ export type ReadableStreamWithFileType = NodeReadableStream & {
 };
 
 /**
- * Extending `FileTypeParser` with Node.js engine specific functions
- */
+Extending `FileTypeParser` with Node.js engine specific functions.
+*/
 export declare class NodeFileTypeParser extends FileTypeParser {
 	/**
 	@param stream - Node.js `stream.Readable` or Web API `ReadableStream`.

--- a/readme.md
+++ b/readme.md
@@ -327,7 +327,7 @@ Returns a `Set<string>` of supported MIME types.
 A custom detector is a function that allows specifying custom detection mechanisms.
 
 An iterable of detectors can be provided via the `fileTypeOptions` argument for the `FileTypeParser` constructor.
-In Node.js you should use `NodeFileTypeParser`, extending `FileTypeParser`, providing access to Node.js specific functions.
+In Node.js, you should use `NodeFileTypeParser`, which extends `FileTypeParser` and provides access to Node.js specific functions.
 
 The detectors are called before the default detections in the provided order.
 

--- a/readme.md
+++ b/readme.md
@@ -127,11 +127,10 @@ Type: `Uint8Array | ArrayBuffer`
 A buffer representing file data. It works best if the buffer contains the entire file. It may work with a smaller portion as well.
 
 ### fileTypeFromFile(filePath)
-
-This method can only be used if the JavaScript engine is Node.js.
-To read from a [File](https://developer.mozilla.org/docs/Web/API/File), please see [fileTypeFromBlob(blob)](#filetypefromblobblob).
-
 Detect the file type of a file path.
+
+This is for Node.js only.
+To read from a [File](https://developer.mozilla.org/docs/Web/API/File), please see [fileTypeFromBlob(blob)](#filetypefromblobblob).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
@@ -150,9 +149,9 @@ The file path to parse.
 
 ### fileTypeFromStream(stream)
 
-Detect the file type of a [Web API ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
-If, and only if the engine used is Node.js, this may also be a [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).
-Support for Node.js streams maybe dropped in the future, when Node.js streams can be converted to Web streams (see [toWeb()](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
+Detect the file type of a [Web ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+If the engine is Node.js, this may also be a [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).
+Direct support for Node.js streams will be dropped in the future, when Node.js streams can be converted to Web streams (see [toWeb()](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
@@ -322,6 +321,7 @@ Returns a `Set<string>` of supported MIME types.
 A custom detector is a function that allows specifying custom detection mechanisms.
 
 An iterable of detectors can be provided via the `fileTypeOptions` argument for the `FileTypeParser` constructor.
+In Node.js you should use `NodeFileTypeParser`, extending `FileTypeParser`, providing access to Node.js specific functions.
 
 The detectors are called before the default detections in the provided order.
 
@@ -337,7 +337,7 @@ If the detector returns `undefined`, there are 2 possible scenarios:
 Example detector array which can be extended and provided to each public method via the `fileTypeOptions` argument:
 
 ```js
-import {FileTypeParser} from 'file-type';
+import {FileTypeParser} from 'file-type'; // or `NodeFileTypeParser` in Node.js
 
 const customDetectors = [
 	async tokenizer => {
@@ -355,7 +355,7 @@ const customDetectors = [
 ];
 
 const buffer = new Uint8Array(new TextEncoder().encode('UNICORN'));
-const parser = new FileTypeParser({customDetectors});
+const parser = new FileTypeParser({customDetectors}); // `NodeFileTypeParser({customDetectors})` in Node.js
 const fileType = await parser.fromBuffer(buffer);
 console.log(fileType);
 ```

--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ A readable stream representing file data.
 ### fileTypeFromBlob(blob)
 
 Detect the file type of a [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob),
+
 [!TIP]
 > A [`File` object](https://developer.mozilla.org/docs/Web/API/File) is a `Blob` and can be passed in here.
 

--- a/readme.md
+++ b/readme.md
@@ -127,10 +127,12 @@ Type: `Uint8Array | ArrayBuffer`
 A buffer representing file data. It works best if the buffer contains the entire file. It may work with a smaller portion as well.
 
 ### fileTypeFromFile(filePath)
+
 Detect the file type of a file path.
 
 This is for Node.js only.
-To read from a [File](https://developer.mozilla.org/docs/Web/API/File), please see [fileTypeFromBlob(blob)](#filetypefromblobblob).
+
+To read from a [`File`](https://developer.mozilla.org/docs/Web/API/File), see [`fileTypeFromBlob()`](#filetypefromblobblob).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ We accept contributions for commonly used modern file formats, not historical or
 npm install file-type
 ```
 
-**This package is a ESM package. Your project needs to be ESM too. [Read more](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).**
+**This package is an ESM package. Your project needs to be ESM too. [Read more](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).**
 
 If you use it with Webpack, you need the latest Webpack version and ensure you configure it correctly for ESM.
 
@@ -149,8 +149,8 @@ The file path to parse.
 
 ### fileTypeFromStream(stream)
 
-Detect the file type of a [Web ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
-If the engine is Node.js, this may also be a [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).
+Detect the file type of a [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+If the engine is Node.js, this may also be a [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable).
 Direct support for Node.js streams will be dropped in the future, when Node.js streams can be converted to Web streams (see [toWeb()](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
@@ -171,7 +171,8 @@ A readable stream representing file data.
 ### fileTypeFromBlob(blob)
 
 Detect the file type of a [Blob](https://developer.mozilla.org/docs/Web/API/Blob),
-and therefor it can also be used for a [File](https://developer.mozilla.org/docs/Web/API/File).
+[!TIP]
+> A [`File` object](https://developer.mozilla.org/docs/Web/API/File) is a `Blob` and can be passed in here.
 
 It will **stream** the underlying Blob, and required a [ReadableStreamBYOBReader](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader) which **require Node.js ≥ 20**.
 

--- a/readme.md
+++ b/readme.md
@@ -151,9 +151,11 @@ The file path to parse.
 
 ### fileTypeFromStream(stream)
 
-Detect the file type of a [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+
 If the engine is Node.js, this may also be a [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable).
-Direct support for Node.js streams will be dropped in the future, when Node.js streams can be converted to Web streams (see [toWeb()](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
+
+Direct support for Node.js streams will be dropped in the future, when Node.js streams can be converted to Web streams (see [`toWeb()`](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,9 @@ A buffer representing file data. It works best if the buffer contains the entire
 
 ### fileTypeFromFile(filePath)
 
+This method can only be used if the JavaScript engine is Node.js.
+To read from a [File](https://developer.mozilla.org/docs/Web/API/File), please see [fileTypeFromBlob(blob)](#filetypefromblobblob).
+
 Detect the file type of a file path.
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
@@ -147,7 +150,9 @@ The file path to parse.
 
 ### fileTypeFromStream(stream)
 
-Detect the file type of a [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) or a [Web API ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+Detect the file type of a [Web API ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+If, and only if the engine used is Node.js, this may also be a [Node.js readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).
+Support for Node.js streams maybe dropped in the future, when Node.js streams can be converted to Web streams (see [toWeb()](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options)).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
@@ -166,11 +171,12 @@ A readable stream representing file data.
 
 ### fileTypeFromBlob(blob)
 
-Detect the file type of a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
+Detect the file type of a [Blob](https://developer.mozilla.org/docs/Web/API/Blob),
+and therefor it can also be used for a [File](https://developer.mozilla.org/docs/Web/API/File).
 
 It will **stream** the underlying Blob, and required a [ReadableStreamBYOBReader](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader) which **require Node.js ≥ 20**.
 
-The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
+The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the blob.
 
 Returns a `Promise` for an object with the detected file type:
 

--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ A readable stream representing file data.
 
 ### fileTypeFromBlob(blob)
 
-Detect the file type of a [Blob](https://developer.mozilla.org/docs/Web/API/Blob),
+Detect the file type of a [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob),
 [!TIP]
 > A [`File` object](https://developer.mozilla.org/docs/Web/API/File) is a `Blob` and can be passed in here.
 


### PR DESCRIPTION
Improve documentation of:

- `fileTypeFromFile(filePath)`: explain this method can only be used if the JavaScript engine is Node.js
- `fileTypeFromStream(stream)` explain that Node.js stream is only available when used with Node.js
- `fileTypeFromBlob(blob)` explain that this is the method to used for web API File

Resolves #640


