### PR TITLE
Improve class method consistency, adding `NodeFileTypeParser.fromFile()`

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -476,6 +476,9 @@ export declare class TokenizerPositionError extends Error {
 export declare class FileTypeParser {
 	detectors: Iterable<Detector>;
 
+	/**
+	 @param options -  `options.customDetectors`: list of custom detectors
+	 */
 	constructor(options?: {customDetectors?: Iterable<Detector>});
 
 	/**

--- a/core.d.ts
+++ b/core.d.ts
@@ -476,9 +476,6 @@ export declare class TokenizerPositionError extends Error {
 export declare class FileTypeParser {
 	detectors: Iterable<Detector>;
 
-	/**
-	 @param options -  `options.customDetectors`: list of custom detectors
-	 */
 	constructor(options?: {customDetectors?: Iterable<Detector>});
 
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ Typings for Node.js specific entry point.
 */
 
 import type {Readable as NodeReadableStream} from 'node:stream';
-import type {FileTypeResult, StreamOptions, AnyWebReadableStream} from './core.js';
+import type {FileTypeResult, StreamOptions, AnyWebReadableStream, Detector} from './core.js';
 import {FileTypeParser} from './core.js';
 
 export type ReadableStreamWithFileType = NodeReadableStream & {
@@ -17,6 +17,11 @@ export declare class NodeFileTypeParser extends FileTypeParser {
 	fromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream): Promise<FileTypeResult | undefined>;
 
 	/**
+   @param path - String with file path
+	 */
+	fromFile(path: string): Promise<FileTypeResult | undefined>;
+
+	/**
 	Works the same way as {@link fileTypeStream}, additionally taking into account custom detectors (if any were provided to the constructor).
 	*/
 	toDetectionStream(readableStream: NodeReadableStream, options?: StreamOptions): Promise<ReadableStreamWithFileType>;
@@ -28,9 +33,10 @@ Detect the file type of a file path.
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
 @param path
+@param options -  `options.customDetectors`: list of custom detectors
 @returns The detected file type and MIME type or `undefined` when there is no match.
 */
-export function fileTypeFromFile(path: string): Promise<FileTypeResult | undefined>;
+export function fileTypeFromFile(path: string, options?: {customDetectors?: Iterable<Detector>}): Promise<FileTypeResult | undefined>;
 
 export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream): Promise<FileTypeResult | undefined>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,10 +16,7 @@ export declare class NodeFileTypeParser extends FileTypeParser {
 	*/
 	fromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream): Promise<FileTypeResult | undefined>;
 
-	/**
-   @param path - String with file path
-	 */
-	fromFile(path: string): Promise<FileTypeResult | undefined>;
+	fromFile(filePath: string): Promise<FileTypeResult | undefined>;
 
 	/**
 	Works the same way as {@link fileTypeStream}, additionally taking into account custom detectors (if any were provided to the constructor).
@@ -30,13 +27,11 @@ export declare class NodeFileTypeParser extends FileTypeParser {
 /**
 Detect the file type of a file path.
 
-The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
+The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the file.
 
-@param path
-@param options -  `options.customDetectors`: list of custom detectors
 @returns The detected file type and MIME type or `undefined` when there is no match.
 */
-export function fileTypeFromFile(path: string, options?: {customDetectors?: Iterable<Detector>}): Promise<FileTypeResult | undefined>;
+export function fileTypeFromFile(filePath: string, options?: {customDetectors?: Iterable<Detector>}): Promise<FileTypeResult | undefined>;
 
 export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream): Promise<FileTypeResult | undefined>;
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,15 @@ export class NodeFileTypeParser extends FileTypeParser {
 		}
 	}
 
+	async fromFile(path) {
+		const tokenizer = await strtok3.fromFile(path);
+		try {
+			return await super.fromTokenizer(tokenizer);
+		} finally {
+			await tokenizer.close();
+		}
+	}
+
 	async toDetectionStream(readableStream, options = {}) {
 		const {default: stream} = await import('node:stream');
 		const {sampleSize = reasonableDetectionSizeInBytes} = options;
@@ -53,13 +62,7 @@ export class NodeFileTypeParser extends FileTypeParser {
 }
 
 export async function fileTypeFromFile(path, fileTypeOptions) {
-	const tokenizer = await strtok3.fromFile(path);
-	try {
-		const parser = new FileTypeParser(fileTypeOptions);
-		return await parser.fromTokenizer(tokenizer);
-	} finally {
-		await tokenizer.close();
-	}
+	return (new NodeFileTypeParser(fileTypeOptions)).fromFile(path, fileTypeOptions);
 }
 
 export async function fileTypeFromStream(stream, fileTypeOptions) {


### PR DESCRIPTION
Changes:
- Improve class method consistency, adding `NodeFileTypeParser.fromFile()`
- Add missing parameter in `fileTypeFromFile`


