### PR TITLE
Add detecting Web Stream to default (core) entry point

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -480,20 +480,10 @@ export type AnyWebReadableByteStreamWithFileType = AnyWebReadableStream<Uint8Arr
 };
 
 /**
-	Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
+Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
 
-	This method can be handy to put in between a stream, but it comes with a price.
-	Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample, to determine the file type.
-	The sample size impacts the file detection resolution.
-	A smaller sample size will result in lower probability of the best file type detection.
-
-	**Note:** This method is only available when using Node.js.
-	**Note:** Requires Node.js 14 or later.
-
-	@param webStream - A Web Stream
-	@param options - Maybe used to override the default sample-size.
-	@returns A `Promise` which resolves to the original web stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
- */
+This method can be handy to put in a stream pipeline, but it comes with a price. Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample, to determine the file type. The sample size impacts the file detection resolution. A smaller sample size will result in lower probability of the best file type detection.
+*/
 export function fileTypeStream(webStream: AnyWebReadableStream<Uint8Array>, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 
 export declare class FileTypeParser {
@@ -518,6 +508,6 @@ export declare class FileTypeParser {
 
 	/**
 	Works the same way as {@link fileTypeStream}, additionally taking into account custom detectors (if any were provided to the constructor).
-	 */
+	*/
 	toDetectionStream(webStream: AnyWebReadableStream<Uint8Array>, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 }

--- a/core.d.ts
+++ b/core.d.ts
@@ -475,6 +475,27 @@ export declare class TokenizerPositionError extends Error {
 	constructor(message?: string);
 }
 
+export type AnyWebReadableByteStreamWithFileType = AnyWebReadableStream<Uint8Array> & {
+	readonly fileType?: FileTypeResult;
+};
+
+/**
+	Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
+
+	This method can be handy to put in between a stream, but it comes with a price.
+	Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample, to determine the file type.
+	The sample size impacts the file detection resolution.
+	A smaller sample size will result in lower probability of the best file type detection.
+
+	**Note:** This method is only available when using Node.js.
+	**Note:** Requires Node.js 14 or later.
+
+	@param webStream - A Web Stream
+	@param options - Maybe used to override the default sample-size.
+	@returns A `Promise` which resolves to the original web stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
+ */
+export function fileTypeStream(webStream: AnyWebReadableStream<Uint8Array>, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
+
 export declare class FileTypeParser {
 	detectors: Iterable<Detector>;
 
@@ -494,4 +515,9 @@ export declare class FileTypeParser {
 	Works the same way as {@link fileTypeFromBlob}, additionally taking into account custom detectors (if any were provided to the constructor).
 	*/
 	fromBlob(blob: Blob): Promise<FileTypeResult | undefined>;
+
+	/**
+	Works the same way as {@link fileTypeStream}, additionally taking into account custom detectors (if any were provided to the constructor).
+	 */
+	toDetectionStream(webStream: AnyWebReadableStream<Uint8Array>, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 }

--- a/core.js
+++ b/core.js
@@ -51,7 +51,7 @@ export async function fileTypeFromTokenizer(tokenizer) {
 	return new FileTypeParser().fromTokenizer(tokenizer);
 }
 
-export async function stream(webStream) {
+export async function fileTypeStream(webStream) {
 	return new FileTypeParser().toDetectionStream(webStream);
 }
 

--- a/core.js
+++ b/core.js
@@ -138,6 +138,7 @@ export class FileTypeParser {
 
 		// Forward remaining data from the reader to the writer
 		(async function pump() {
+			// Read a 512 kB chunk, where the chunk size is an instinctively chosen value
 			const {value, done} = await reader.read(new Uint8Array(512 * 1024));
 			if (done) {
 				return writer.close();

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,20 +60,17 @@ export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array> | No
 /**
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
 
-This method  can be handy to put in between a stream, but it comes with a price.
+This method can be handy to put in between a stream, but it comes with a price.
 Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample, to determine the file type.
 The sample size impacts the file detection resolution.
 A smaller sample size will result in lower probability of the best file type detection.
 
-**Note:** This method is only available when using Node.js.
-**Note:** Requires Node.js 14 or later.
-
-@param readableStream - A [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
-or [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream), streaming a file to examine.
+@param readableStream - A [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable), streaming a file to examine.
 @param options - May be used to override the default sample size.
 @returns A `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
+
 @example
- ```
+```
 import got from 'got';
 import {fileTypeStream} from 'file-type';
 
@@ -86,7 +83,7 @@ if (stream2.fileType?.mime === 'image/jpeg') {
 	// stream2 can be used to stream the JPEG image (from the very beginning of the stream)
 }
 ```
- */
+*/
 export function fileTypeStream(readableStream: NodeReadableStream, options?: StreamOptions): Promise<ReadableStreamWithFileType>;
 export function fileTypeStream(webStream: AnyWebReadableStream<Uint8Array>, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,8 +14,6 @@ export type ReadableStreamWithFileType = NodeReadableStream & {
 Extending `FileTypeParser` with Node.js engine specific functions.
 */
 export declare class NodeFileTypeParser extends FileTypeParser {
-	constructor(options?: {customDetectors?: Iterable<Detector>});
-
 	/**
 	@param stream - Node.js `stream.Readable` or web `ReadableStream`.
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array> | No
 /**
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
 
-This method can be handy to put in between a stream, but it comes with a price.
+This method  can be handy to put in between a stream, but it comes with a price.
 Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample, to determine the file type.
 The sample size impacts the file detection resolution.
 A smaller sample size will result in lower probability of the best file type detection.
@@ -68,11 +68,11 @@ A smaller sample size will result in lower probability of the best file type det
 **Note:** This method is only available when using Node.js.
 **Note:** Requires Node.js 14 or later.
 
-@param readableStream - A [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) containing a file to examine.
-@param options - May be used to override the default sample size with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
-
-@example
-@returns A `Promise` which resolves to the original readable stream argument, but
+@param readableStream - A [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
+or [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream), streaming a file to examine.
+@param options - May be used to override the default sample size with an added `fileType` property, wh` property, which is an object like the one returned from `fileTypeFromFile()`.
+@exampleich is an object like the one returned from `fileTypeFromFile()`.
+@returns A `Promise` which resolves to the original readable stream argument, but with an added `fileType
 ```
 import got from 'got';
 import {fileTypeStream} from 'file-type';

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,10 +70,10 @@ A smaller sample size will result in lower probability of the best file type det
 
 @param readableStream - A [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
 or [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream), streaming a file to examine.
-@param options - May be used to override the default sample size with an added `fileType` property, wh` property, which is an object like the one returned from `fileTypeFromFile()`.
-@exampleich is an object like the one returned from `fileTypeFromFile()`.
-@returns A `Promise` which resolves to the original readable stream argument, but with an added `fileType
-```
+@param options - May be used to override the default sample size.
+@returns A `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
+@example
+ ```
 import got from 'got';
 import {fileTypeStream} from 'file-type';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ Typings for Node.js specific entry point.
 */
 
 import type {Readable as NodeReadableStream} from 'node:stream';
-import type {FileTypeResult, StreamOptions, AnyWebReadableStream, Detector} from './core.js';
+import type {FileTypeResult, StreamOptions, AnyWebReadableStream, Detector, AnyWebReadableByteStreamWithFileType} from './core.js';
 import {FileTypeParser} from './core.js';
 
 export type ReadableStreamWithFileType = NodeReadableStream & {
@@ -27,6 +27,7 @@ export declare class NodeFileTypeParser extends FileTypeParser {
 	Works the same way as {@link fileTypeStream}, additionally taking into account custom detectors (if any were provided to the constructor).
 	*/
 	toDetectionStream(readableStream: NodeReadableStream, options?: StreamOptions): Promise<ReadableStreamWithFileType>;
+	toDetectionStream(webStream: AnyWebReadableStream<Uint8Array>, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 }
 
 /**
@@ -70,10 +71,10 @@ A smaller sample size will result in lower probability of the best file type det
 **Note:** Requires Node.js 14 or later.
 
 @param readableStream - A [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) containing a file to examine.
-@param options - Maybe used to override the default sample-size.
-@returns A `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
+@param options - Maybe used to override the default sample-size.with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
 
 @example
+@returns A `Promise` which resolves to the original readable stream argument, but
 ```
 import got from 'got';
 import {fileTypeStream} from 'file-type';
@@ -89,5 +90,6 @@ if (stream2.fileType?.mime === 'image/jpeg') {
 ```
  */
 export function fileTypeStream(readableStream: NodeReadableStream, options?: StreamOptions): Promise<ReadableStreamWithFileType>;
+export function fileTypeStream(webStream: AnyWebReadableStream<Uint8Array>, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 
 export * from './core.js';

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,7 @@ A smaller sample size will result in lower probability of the best file type det
 **Note:** Requires Node.js 14 or later.
 
 @param readableStream - A [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable) containing a file to examine.
-@param options - Maybe used to override the default sample-size.with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
+@param options - May be used to override the default sample size with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
 
 @example
 @returns A `Promise` which resolves to the original readable stream argument, but

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
 		"vsdx"
 	],
 	"dependencies": {
+		"get-stream": "^9.0.1",
 		"strtok3": "^8.0.0",
 		"token-types": "^6.0.0",
 		"uint8array-extras": "^1.3.0"

--- a/readme.md
+++ b/readme.md
@@ -167,8 +167,10 @@ Returns a `Promise` for an object with the detected file type:
 Or `undefined` when there is no match.
 
 #### stream
+Streaming a file to examine.
 
-Type: [`stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
+Type: [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
+or [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
 
 A readable stream representing file data.
 

--- a/readme.md
+++ b/readme.md
@@ -167,10 +167,8 @@ Returns a `Promise` for an object with the detected file type:
 Or `undefined` when there is no match.
 
 #### stream
-Streaming a file to examine.
 
-Type: [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
-or [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+Type: [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable)
 
 A readable stream representing file data.
 

--- a/test.js
+++ b/test.js
@@ -891,7 +891,7 @@ test('fileTypeFromTokenizer should return undefined when a custom detector chang
 	const header = 'UNICORN FILE\n';
 	const uint8ArrayContent = new TextEncoder().encode(header);
 
-	// Include the unicormDetector here to verify it's not used after the tokenizer.position changed
+	// Include the unicornDetector here to verify it's not used after the tokenizer.position changed
 	const customDetectors = [tokenizerPositionChanger, unicornDetector];
 	const parser = new NodeFileTypeParser({customDetectors});
 


### PR DESCRIPTION
In addition to the `fileTypeStream()` converting a Node Readable stream, into a detecting stream, add support for web streams.

In Node.js you can either use a Node Readable stream, or a Web Stream.
Using the default entry point (core), just supports Web Stream.