### PR TITLE
Fix options in combination with function `fileTypeStream()`

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,0 @@
-<component name="ProjectCodeStyleConfiguration">
-  <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
-  </state>
-</component>

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ export async function fileTypeFromStream(stream, fileTypeOptions) {
 }
 
 export async function fileTypeStream(readableStream, options = {}) {
-	return new NodeFileTypeParser().toDetectionStream(readableStream, options);
+	return new NodeFileTypeParser(options).toDetectionStream(readableStream, options);
 }
 
 export {fileTypeFromTokenizer, fileTypeFromBuffer, fileTypeFromBlob, FileTypeParser, supportedMimeTypes, supportedExtensions} from './core.js';

--- a/readme.md
+++ b/readme.md
@@ -265,7 +265,7 @@ Type: [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer)
 
 A file source implementing the [tokenizer interface](https://github.com/Borewit/strtok3#tokenizer).
 
-### fileTypeStream(readableStream, options?)
+### fileTypeStream(webStream, options?)
 
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
 
@@ -274,8 +274,8 @@ Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample
 The sample size impacts the file detection resolution.
 A smaller sample size will result in lower probability of the best file type detection.
 
-**Note:** This method is only available when using Node.js.
-**Note:** Requires Node.js 14 or later.
+**Note:** When using Node.js, a stream Readable maybe provided as well.
+**Note:** Require[readme.md](readme.md)s Node.js 14 or later.
 
 #### readableStream
 

--- a/readme.md
+++ b/readme.md
@@ -274,8 +274,7 @@ Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample
 The sample size impacts the file detection resolution.
 A smaller sample size will result in lower probability of the best file type detection.
 
-**Note:** When using Node.js, a stream Readable maybe provided as well.
-**Note:** Require[readme.md](readme.md)s Node.js 14 or later.
+**Note:** When using Node.js, a `stream.Readable` may be provided as well.
 
 #### readableStream
 


### PR DESCRIPTION
When using method `fileTypeStream`, any options other then the `sampleSize` was ignored.

This PR correctly passes the options to the `NodeFileTypeParser` 