### PR TITLE
Fix passing options to `fileTypeStream` in default entry point

### DIFF
--- a/core.js
+++ b/core.js
@@ -51,8 +51,8 @@ export async function fileTypeFromTokenizer(tokenizer) {
 	return new FileTypeParser().fromTokenizer(tokenizer);
 }
 
-export async function fileTypeStream(webStream) {
-	return new FileTypeParser().toDetectionStream(webStream);
+export async function fileTypeStream(webStream, options) {
+	return new FileTypeParser(options).toDetectionStream(webStream, options);
 }
 
 export class FileTypeParser {


### PR DESCRIPTION
Similar to #650, fixing Node entry point, this fix addresses a similar mistake in the default entry point