### PR TITLE
Test for `instanceof` Readable as for this class Node.js is the single supplier

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ Node.js specific entry point.
 */
 
 import {ReadableStream as WebReadableStream} from 'node:stream/web';
-import {pipeline, PassThrough} from 'node:stream';
+import {pipeline, PassThrough, Readable} from 'node:stream';
 import * as strtok3 from 'strtok3';
 import {FileTypeParser, reasonableDetectionSizeInBytes} from './core.js';
 
@@ -27,7 +27,7 @@ export class NodeFileTypeParser extends FileTypeParser {
 	}
 
 	async toDetectionStream(readableStream, options = {}) {
-		if (readableStream instanceof WebReadableStream) {
+		if (!(readableStream instanceof Readable)) {
 			return super.toDetectionStream(readableStream, options);
 		}
 


### PR DESCRIPTION
Aim of this PR is to avoid web streams are not correctly detected.
I am not sure if this situation can occur.

