### PR TITLE
Reuse strtok3 typing for different web stream types

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -3,7 +3,7 @@ Typings for primary entry point, Node.js specific typings can be found in index.
 */
 
 import type {ReadableStream as WebReadableStream} from 'node:stream/web';
-import type {ITokenizer} from 'strtok3';
+import type {ITokenizer, AnyWebByteStream} from 'strtok3';
 
 /**
 Either the Node.js ReadableStream or the `lib.dom.d.ts` ReadableStream.
@@ -350,7 +350,7 @@ The file type is detected by checking the [magic number](https://en.wikipedia.or
 @param stream - A [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
 @returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
 */
-export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array>): Promise<FileTypeResult | undefined>;
+export function fileTypeFromStream(stream: AnyWebByteStream): Promise<FileTypeResult | undefined>;
 
 /**
 Detect the file type from an [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer) source.

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ Typings for Node.js specific entry point.
 */
 
 import type {Readable as NodeReadableStream} from 'node:stream';
+import type {AnyWebByteStream} from 'strtok3';
 import type {FileTypeResult, StreamOptions, AnyWebReadableStream, Detector, AnyWebReadableByteStreamWithFileType} from './core.js';
 import {FileTypeParser} from './core.js';
 
@@ -85,6 +86,6 @@ if (stream2.fileType?.mime === 'image/jpeg') {
 ```
 */
 export function fileTypeStream(readableStream: NodeReadableStream, options?: StreamOptions): Promise<ReadableStreamWithFileType>;
-export function fileTypeStream(webStream: AnyWebReadableStream<Uint8Array>, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
+export function fileTypeStream(webStream: AnyWebByteStream, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 
 export * from './core.js';

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
 	],
 	"dependencies": {
 		"get-stream": "^9.0.1",
-		"strtok3": "^8.0.0",
+		"strtok3": "^8.1.0",
 		"token-types": "^6.0.0",
 		"uint8array-extras": "^1.3.0"
 	},


### PR DESCRIPTION
Reuse any web byte stream definition from [strtok3](https://github.com/Borewit/strtok3)