### PR TITLE
Add CommonJS entry points

### DIFF
--- a/core.cjs
+++ b/core.cjs
@@ -1,0 +1,7 @@
+/**
+ * CommonJS core (default) entry point
+ */
+
+module.exports = {
+	loadFileType: () => import('./core.js'),
+};

--- a/node.cjs
+++ b/node.cjs
@@ -1,0 +1,7 @@
+/**
+ * CommonJS Node entry point
+ */
+
+module.exports = {
+	loadFileType: () => import('./index.js'),
+};

--- a/package.json
+++ b/package.json
@@ -15,16 +15,19 @@
 		".": {
 			"node": {
 				"types": "./index.d.ts",
-				"import": "./index.js"
+				"import": "./index.js",
+				"require": "./node.cjs"
 			},
 			"default": {
 				"types": "./core.d.ts",
-				"import": "./core.js"
+				"import": "./core.js",
+				"require": "./core.cjs"
 			}
 		},
 		"./core": {
 			"types": "./core.d.ts",
-			"import": "./core.js"
+			"import": "./core.js",
+			"require": "./core.cjs"
 		}
 	},
 	"sideEffects": false,


### PR DESCRIPTION
Just out of curiosity, as there are so many issues with legacy CommonJS projects, trying to import this pure ESM module.
Would this solution help a bit?

I added 2 CommonJS `require` entry points to the export:
1.  `core.cjs`,  CommonJS default entry-point
1. `node.cjs`, Node.js entry-points. 

Each entry point provides a function to load (using `loadFileType`) the ESM module asynchronous for CommonJS use.

```js
const { loadFileType } = require('file-type');

(async () => {
    const { fileTypeFromFile } = await loadFileType(); // Load the ESM file-type module async
    const type = await fileTypeFromFile('fixture.gif');
    console.log(type);
})();
```

Would this help?

Related to #661 and many more issues