### PR TITLE
Add ability to abort async operations

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -489,7 +489,7 @@ export function fileTypeStream(webStream: AnyWebReadableStream<Uint8Array>, opti
 export declare class FileTypeParser {
 	detectors: Iterable<Detector>;
 
-	constructor(options?: {customDetectors?: Iterable<Detector>});
+	constructor(options?: {customDetectors?: Iterable<Detector>; abortSignal: AbortSignal});
 
 	/**
 	Works the same way as {@link fileTypeFromBuffer}, additionally taking into account custom detectors (if any were provided to the constructor).

--- a/core.d.ts
+++ b/core.d.ts
@@ -489,7 +489,7 @@ export function fileTypeStream(webStream: AnyWebReadableStream<Uint8Array>, opti
 export declare class FileTypeParser {
 	detectors: Iterable<Detector>;
 
-	constructor(options?: {customDetectors?: Iterable<Detector>; abortSignal: AbortSignal});
+	constructor(options?: {customDetectors?: Iterable<Detector>; signal: AbortSignal});
 
 	/**
 	Works the same way as {@link fileTypeFromBuffer}, additionally taking into account custom detectors (if any were provided to the constructor).

--- a/core.js
+++ b/core.js
@@ -58,7 +58,9 @@ export async function fileTypeStream(webStream, options) {
 export class FileTypeParser {
 	constructor(options) {
 		this.detectors = options?.customDetectors;
-
+		this.tokenizerOptions = {
+			abortSignal: options?.abortSignal,
+		};
 		this.fromTokenizer = this.fromTokenizer.bind(this);
 		this.fromBuffer = this.fromBuffer.bind(this);
 		this.parse = this.parse.bind(this);
@@ -92,7 +94,7 @@ export class FileTypeParser {
 			return;
 		}
 
-		return this.fromTokenizer(strtok3.fromBuffer(buffer));
+		return this.fromTokenizer(strtok3.fromBuffer(buffer, this.tokenizerOptions));
 	}
 
 	async fromBlob(blob) {
@@ -100,7 +102,7 @@ export class FileTypeParser {
 	}
 
 	async fromStream(stream) {
-		const tokenizer = await strtok3.fromWebStream(stream);
+		const tokenizer = await strtok3.fromWebStream(stream, this.tokenizerOptions);
 		try {
 			return await this.fromTokenizer(tokenizer);
 		} finally {

--- a/core.js
+++ b/core.js
@@ -59,7 +59,7 @@ export class FileTypeParser {
 	constructor(options) {
 		this.detectors = options?.customDetectors;
 		this.tokenizerOptions = {
-			abortSignal: options?.abortSignal,
+			abortSignal: options?.signal,
 		};
 		this.fromTokenizer = this.fromTokenizer.bind(this);
 		this.fromBuffer = this.fromBuffer.bind(this);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ import {FileTypeParser, reasonableDetectionSizeInBytes} from './core.js';
 
 export class NodeFileTypeParser extends FileTypeParser {
 	async fromStream(stream) {
-		const tokenizer = await (stream instanceof WebReadableStream ? strtok3.fromWebStream(stream) : strtok3.fromStream(stream));
+		const tokenizer = await (stream instanceof WebReadableStream ? strtok3.fromWebStream(stream, this.tokenizerOptions) : strtok3.fromStream(stream, this.tokenizerOptions));
 		try {
 			return super.fromTokenizer(tokenizer);
 		} finally {

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
 	],
 	"dependencies": {
 		"get-stream": "^9.0.1",
-		"strtok3": "^8.1.0",
+		"strtok3": "^9.0.0",
 		"token-types": "^6.0.0",
 		"uint8array-extras": "^1.3.0"
 	},

--- a/readme.md
+++ b/readme.md
@@ -367,6 +367,22 @@ const fileType = await parser.fromBuffer(buffer);
 console.log(fileType);
 ```
 
+## Abort signal
+
+Some asynchronous operations can be aborted by passing the [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) interface to the `FileTypeParser` constructor.
+
+```js
+import {FileTypeParser} from 'file-type'; // or `NodeFileTypeParser` in Node.js
+
+const abortController = new AbortController()
+
+const parser = new FileTypeParser({abortSignal: abortController.signal});
+
+const promise = parser.fromStream(blob.stream());
+
+abortController.abort(); // Abort file-type reading from the Blob stream.
+```
+
 ## Supported file types
 
 - [`3g2`](https://en.wikipedia.org/wiki/3GP_and_3G2#3G2) - Multimedia container format defined by the 3GPP2 for 3G CDMA2000 multimedia services

--- a/readme.md
+++ b/readme.md
@@ -369,7 +369,7 @@ console.log(fileType);
 
 ## Abort signal
 
-Some asynchronous operations can be aborted by passing the [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) interface to the `FileTypeParser` constructor.
+Some async operations can be aborted by passing an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to the `FileTypeParser` constructor.
 
 ```js
 import {FileTypeParser} from 'file-type'; // or `NodeFileTypeParser` in Node.js

--- a/test.js
+++ b/test.js
@@ -473,7 +473,7 @@ test('.fileTypeFromStream() method - be able to abort operation', async t => {
 
 	const shortStream = new MyStream();
 	const abortController = new AbortController();
-	const parser = new NodeFileTypeParser({abortSignal: abortController.signal});
+	const parser = new NodeFileTypeParser({signal: abortController.signal});
 	const promiseFileType = parser.fromStream(shortStream);
 	abortController.abort(); // Abort asynchronous operation: reading from shortStream
 	const error = await t.throwsAsync(promiseFileType);


### PR DESCRIPTION
Changes:
- Support [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
- Update [strtok3](https://github.com/Borewit/strtok3) to version [v9.0.0](https://github.com/Borewit/strtok3/releases/tag/v9.0.0)