### PR TITLE
Improve Nikon RAW NEF (Tiff) format detection

### DIFF
--- a/core.js
+++ b/core.js
@@ -1706,11 +1706,18 @@ export class FileTypeParser {
 					};
 				}
 
-				if (ifdOffset >= 8 && (this.check([0x1C, 0x00, 0xFE, 0x00], {offset: 8}) || this.check([0x1F, 0x00, 0x0B, 0x00], {offset: 8}))) {
-					return {
-						ext: 'nef',
-						mime: 'image/x-nikon-nef',
-					};
+				if (ifdOffset >= 8) {
+					const someId1 = (bigEndian ? Token.UINT16_BE : Token.UINT16_LE).get(this.buffer, 8);
+					const someId2 = (bigEndian ? Token.UINT16_BE : Token.UINT16_LE).get(this.buffer, 10);
+
+					if (
+						(someId1 === 0x1C && someId2 === 0xFE)
+						|| (someId1 === 0x1F && someId2 === 0x0B)) {
+						return {
+							ext: 'nef',
+							mime: 'image/x-nikon-nef',
+						};
+					}
 				}
 			}
 

--- a/package.json
+++ b/package.json
@@ -220,7 +220,8 @@
 		"apk"
 	],
 	"dependencies": {
-		"strtok3": "^9.0.1",
+		"get-stream": "^9.0.1",
+		"strtok3": "^10.0.0",
 		"token-types": "^6.0.0",
 		"uint8array-extras": "^1.3.0"
 	},


### PR DESCRIPTION
Presumably resolves #624 

Some of the difference are caused by bytes being swapped, which looks like differences in [endianness](https://en.wikipedia.org/wiki/Endianness).
