### PR TITLE
Return `pptx` type based on `/ppt*` path prefix occurrence in zipped files

### DIFF
--- a/core.js
+++ b/core.js
@@ -456,6 +456,13 @@ export class FileTypeParser {
 						};
 					}
 
+					if (zipHeader.filename.startsWith('ppt/')) {
+						return {
+							ext: 'pptx',
+							mime: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+						};
+					}
+
 					if (zipHeader.filename.startsWith('3D/') && zipHeader.filename.endsWith('.model')) {
 						return {
 							ext: '3mf',


### PR DESCRIPTION
Similar to how xlsx is shortcutted based on the path filename of the zipped headers, I have done the same for pptx.

Please feel free to reject if this is totally wrong and not a safe or acceptable way to detect pptx files. In my testing this commit made detetcting this file go from 7 mintues to a few seconds.

Resolves #688 