### PR TITLE
Correct typing option `signal` to be optional

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -493,7 +493,7 @@ export function fileTypeStream(webStream: AnyWebReadableStream<Uint8Array>, opti
 export declare class FileTypeParser {
 	detectors: Iterable<Detector>;
 
-	constructor(options?: {customDetectors?: Iterable<Detector>; signal: AbortSignal});
+	constructor(options?: {customDetectors?: Iterable<Detector>; signal?: AbortSignal});
 
 	/**
 	Works the same way as {@link fileTypeFromBuffer}, additionally taking into account custom detectors (if any were provided to the constructor).


### PR DESCRIPTION
Make option `signal` [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
) optional.

Introduced in #667

