### PR TITLE
Update dependency strtok3 to from `^9.0.1` to version `^10.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
 	],
 	"dependencies": {
 		"get-stream": "^9.0.1",
-		"strtok3": "^9.0.1",
+		"strtok3": "^10.0.0",
 		"token-types": "^6.0.0",
 		"uint8array-extras": "^1.3.0"
 	},


### PR DESCRIPTION
Most import change in [strtok3 version 10](https://github.com/Borewit/strtok3/releases/tag/v10.0.0)   is the `option.offset` being eprecated, however this option was not being used by `file-type`.
