### PR TITLE
Separate confident and imprecise detectors, introduce detector identification

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ If you're adding support for a new file type, please follow the below steps:
 	- Signature with shorter sample size (counted from offset 0 until the last required byte position) will be executed first.
 	- Only the initial determination for the file type counts for the sequence.
 	- Existing signatures requiring same sample length (same *signature group*) will be tested prior to your new detections. Yours will be last. (rational: common formats first).
+- Unsafe detection (higher risk false positive detection) will be performed after safe detections, they should be added to `detectUnsafe()`
 - Add the file extension to the `Supported file types` section of the readme in alphabetical order, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```
 - Add the file extension to the `keywords` array in the `package.json` file.
 - Run `$ npm test` to ensure the tests pass.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,8 @@ If you're adding support for a new file type, please follow the below steps:
 - Add the file's MIME type to the `types` array in `supported.js`.
 - Add the file type detection logic to the `core.js` file
 - Determine the appropriate detection confidence category:
-    - `detectConfident()`: Detections with a high degree of certainty in identifying the correct file type
-    - `detectImprecise()`: Detections with limited supporting data, resulting in a higher likelihood of false positives
+	- `detectConfident()`: Detections with a high degree of certainty in identifying the correct file type
+	- `detectImprecise()`: Detections with limited supporting data, resulting in a higher likelihood of false positives
 - Respect the sequence:
 	- Signature with shorter sample size (counted from offset 0 until the last required byte position) will be executed first.
 	- Only the initial determination for the file type counts for the sequence.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,10 +4,10 @@ If you're adding support for a new file type, please follow the below steps:
 - Add a fixture file named `fixture.<extension>` to the `fixture` directory.
 - Add the file extension to the `extensions` array in `supported.js`.
 - Add the file's MIME type to the `types` array in `supported.js`.
-- Add the file type detection logic to the `core.js` file
+- Add the file type detection logic to the `core.js` file.
 - Determine the appropriate detection confidence category:
-	- `detectConfident()`: Detections with a high degree of certainty in identifying the correct file type
-	- `detectImprecise()`: Detections with limited supporting data, resulting in a higher likelihood of false positives
+	- `detectConfident()`: Detections with a high degree of certainty in identifying the correct file type.
+	- `detectImprecise()`: Detections with limited supporting data, resulting in a higher likelihood of false positives.
 - Respect the sequence:
 	- Signature with shorter sample size (counted from offset 0 until the last required byte position) will be executed first.
 	- Only the initial determination for the file type counts for the sequence.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,11 +5,13 @@ If you're adding support for a new file type, please follow the below steps:
 - Add the file extension to the `extensions` array in `supported.js`.
 - Add the file's MIME type to the `types` array in `supported.js`.
 - Add the file type detection logic to the `core.js` file
+- Determine the appropriate detection confidence category:
+    - `detectConfident()`: Detections with a high degree of certainty in identifying the correct file type
+    - `detectImprecise()`: Detections with limited supporting data, resulting in a higher likelihood of false positives
 - Respect the sequence:
 	- Signature with shorter sample size (counted from offset 0 until the last required byte position) will be executed first.
 	- Only the initial determination for the file type counts for the sequence.
 	- Existing signatures requiring same sample length (same *signature group*) will be tested prior to your new detections. Yours will be last. (rational: common formats first).
-- Unsafe detection (higher risk false positive detection) will be performed after safe detections, they should be added to `detectUnsafe()`
 - Add the file extension to the `Supported file types` section of the readme in alphabetical order, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```
 - Add the file extension to the `keywords` array in the `package.json` file.
 - Run `$ npm test` to ensure the tests pass.

--- a/core.d.ts
+++ b/core.d.ts
@@ -162,7 +162,10 @@ console.log(fileType); // {ext: 'unicorn', mime: 'application/unicorn'}
 @param fileType - The file type detected by standard or previous custom detectors, or `undefined` if no match is found.
 @returns The detected file type, or `undefined` if no match is found.
 */
-export type Detector = (tokenizer: ITokenizer, fileType?: FileTypeResult) => Promise<FileTypeResult | undefined>;
+export type Detector = {
+	id: string;
+	detect: (tokenizer: ITokenizer, fileType?: FileTypeResult) => Promise<FileTypeResult | undefined>;
+};
 
 export type FileTypeOptions = {
 	customDetectors?: Iterable<Detector>;

--- a/core.js
+++ b/core.js
@@ -130,8 +130,8 @@ export async function fileTypeStream(webStream, options) {
 export class FileTypeParser {
 	constructor(options) {
 		this.detectors = [...(options?.customDetectors ?? []),
-			{id: 'core.safe', detect: this.detectCore},
-			{id: 'core.unsafe', detect: this.detectUnsafe}];
+			{id: 'core', detect: this.detectConfident},
+			{id: 'core.imprecise', detect: this.detectImprecise}];
 		this.tokenizerOptions = {
 			abortSignal: options?.signal,
 		};
@@ -233,7 +233,8 @@ export class FileTypeParser {
 		return this.check(stringToBytes(header), options);
 	}
 
-	detectCore = async tokenizer => {
+	// Detections with a high degree of certainty in identifying the correct file type
+	detectConfident = async tokenizer => {
 		this.buffer = new Uint8Array(reasonableDetectionSizeInBytes);
 
 		// Keep reading until EOF if the file size is unknown.
@@ -323,7 +324,7 @@ export class FileTypeParser {
 		if (this.check([0xEF, 0xBB, 0xBF])) { // UTF-8-BOM
 			// Strip off UTF-8-BOM
 			this.tokenizer.ignore(3);
-			return this.detectCore(tokenizer);
+			return this.detectConfident(tokenizer);
 		}
 
 		if (this.check([0x47, 0x49, 0x46])) {
@@ -1590,7 +1591,8 @@ export class FileTypeParser {
 		}
 	};
 
-	detectUnsafe = async tokenizer => {
+	// Detections with limited supporting data, resulting in a higher likelihood of false positives
+	detectImprecise = async tokenizer => {
 		this.buffer = new Uint8Array(reasonableDetectionSizeInBytes);
 
 		// Read initial sample size of 8 bytes

--- a/readme.md
+++ b/readme.md
@@ -364,8 +364,9 @@ Below is an example of a custom detector array. This can be passed to the `FileT
 ```js
 import {FileTypeParser} from 'file-type';
 
-const customDetectors = [
-	async tokenizer => {
+const unicornDetector = {
+	id: 'unicorn',
+  	async detect(tokenizer) {
 		const unicornHeader = [85, 78, 73, 67, 79, 82, 78]; // "UNICORN" in ASCII decimal
 
 		const buffer = new Uint8Array(unicornHeader.length);
@@ -375,11 +376,11 @@ const customDetectors = [
 		}
 
 		return undefined;
-	},
-];
+	}
+}
 
 const buffer = new Uint8Array([85, 78, 73, 67, 79, 82, 78]);
-const parser = new FileTypeParser({customDetectors});
+const parser = new FileTypeParser({customDetectors: [unicornDetector]});
 const fileType = await parser.fromBuffer(buffer);
 console.log(fileType); // {ext: 'unicorn', mime: 'application/unicorn'}
 ```

--- a/readme.md
+++ b/readme.md
@@ -365,7 +365,7 @@ Below is an example of a custom detector array. This can be passed to the `FileT
 import {FileTypeParser} from 'file-type';
 
 const unicornDetector = {
-	id: 'unicorn',
+	id: 'unicorn', // May be used to recognize the detector in the detector list
   	async detect(tokenizer) {
 		const unicornHeader = [85, 78, 73, 67, 79, 82, 78]; // "UNICORN" in ASCII decimal
 

--- a/test.js
+++ b/test.js
@@ -688,22 +688,31 @@ test('corrupt MKV throws', async t => {
 });
 
 // Create a custom detector for the just made up "unicorn" file type
-const unicornDetector = async tokenizer => {
-	const unicornHeader = [85, 78, 73, 67, 79, 82, 78]; // "UNICORN" as decimal string
-	const buffer = new Uint8Array(7);
-	await tokenizer.peekBuffer(buffer, {length: unicornHeader.length, mayBeLess: true});
-	if (unicornHeader.every((value, index) => value === buffer[index])) {
-		return {ext: 'unicorn', mime: 'application/unicorn'};
-	}
+const unicornDetector = {
+	id: 'mock.unicorn',
+	async detect(tokenizer) {
+		const unicornHeader = [85, 78, 73, 67, 79, 82, 78]; // "UNICORN" as decimal string
+		const buffer = new Uint8Array(7);
+		await tokenizer.peekBuffer(buffer, {length: unicornHeader.length, mayBeLess: true});
+		if (unicornHeader.every((value, index) => value === buffer[index])) {
+			return {ext: 'unicorn', mime: 'application/unicorn'};
+		}
 
-	return undefined;
+		return undefined;
+	},
 };
 
-const mockPngDetector = _tokenizer => ({ext: 'mockPng', mime: 'image/mockPng'});
+const mockPngDetector = {
+	id: 'mock.png',
+	detect: () => ({ext: 'mockPng', mime: 'image/mockPng'}),
+};
 
-const tokenizerPositionChanger = tokenizer => {
-	const buffer = new Uint8Array(1);
-	tokenizer.readBuffer(buffer, {length: 1, mayBeLess: true});
+const tokenizerPositionChanger = {
+	id: 'mock.dirtyTokenizer',
+	detect(tokenizer) {
+		const buffer = new Uint8Array(1);
+		tokenizer.readBuffer(buffer, {length: 1, mayBeLess: true});
+	},
 };
 
 if (nodeMajorVersion >= nodeVersionSupportingByteBlobStream) {


### PR DESCRIPTION
Extend the `Detector` type with an `id` property, which allows users to understand which detector is doing what. The core detectors are seperated in:
- `default.safe`: Safe core detectors
- `default.unsafe`: Collection of detectors with higher probability of false positive

Resolves: #483