### PR TITLE
fix: Fix require(ESM) for Node v22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "file-type",
-	"version": "19.6.0",
+	"version": "20.0.0",
 	"description": "Detect the file type of a file, stream, or data",
 	"license": "MIT",
 	"repository": "sindresorhus/file-type",

--- a/package.json
+++ b/package.json
@@ -15,16 +15,19 @@
 		".": {
 			"node": {
 				"types": "./index.d.ts",
-				"import": "./index.js"
+				"import": "./index.js",
+				"require": "./index.js"
 			},
 			"default": {
 				"types": "./core.d.ts",
-				"import": "./core.js"
+				"import": "./core.js",
+				"require": "./core.js"
 			}
 		},
 		"./core": {
 			"types": "./core.d.ts",
-			"import": "./core.js"
+			"import": "./core.js",
+			"require": "./core.js"
 		}
 	},
 	"sideEffects": false,


### PR DESCRIPTION
Fixes for Node 22:
- https://github.com/sindresorhus/file-type/issues/696
- https://github.com/sindresorhus/file-type/issues/671
- https://github.com/sindresorhus/file-type/issues/668
- https://github.com/sindresorhus/file-type/issues/661
- https://github.com/sindresorhus/file-type/issues/600
- ... and similar

Is that correct?
