### PR TITLE
Update `strtok3` dependency to version `^10.2.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
 	],
 	"dependencies": {
 		"@tokenizer/inflate": "^0.2.6",
-		"strtok3": "^10.0.1",
+		"strtok3": "^10.2.0",
 		"token-types": "^6.0.0",
 		"uint8array-extras": "^1.4.0"
 	},

--- a/test.js
+++ b/test.js
@@ -491,7 +491,7 @@ test('.fileTypeFromStream() method - be able to abort operation', async t => {
 	const promiseFileType = parser.fromStream(shortStream);
 	abortController.abort(); // Abort asynchronous operation: reading from shortStream
 	const error = await t.throwsAsync(promiseFileType);
-	t.is(error.message, 'Stream closed');
+	t.true(error instanceof strtok3.AbortError, 'Expect error te be an instanceof AbortError');
 });
 
 test('supportedExtensions.has', t => {


### PR DESCRIPTION
This version throws an `AbortError` instead of an `EndOfStreamError`, if a pending tokenizer read operation is aborted, or in case the stream is closed. 

Adjust unit test to test on `AbortError` thrown when async operation is aborted.

Without this merge, future CI shall will fail.