### PR TITLE
Fix detecting small PDF file

### DIFF
--- a/core.js
+++ b/core.js
@@ -726,17 +726,19 @@ export class FileTypeParser {
 
 		if (this.checkString('%PDF')) {
 			try {
-				await tokenizer.ignore(1350);
-				const maxBufferSize = 10 * 1024 * 1024;
-				const buffer = new Uint8Array(Math.min(maxBufferSize, tokenizer.fileInfo.size));
-				await tokenizer.readBuffer(buffer, {mayBeLess: true});
+				const skipBytes = 1350;
+				if (skipBytes === await tokenizer.ignore(skipBytes)) {
+					const maxBufferSize = 10 * 1024 * 1024;
+					const buffer = new Uint8Array(Math.min(maxBufferSize, tokenizer.fileInfo.size - skipBytes));
+					await tokenizer.readBuffer(buffer, {mayBeLess: true});
 
-				// Check if this is an Adobe Illustrator file
-				if (includes(buffer, new TextEncoder().encode('AIPrivateData'))) {
-					return {
-						ext: 'ai',
-						mime: 'application/postscript',
-					};
+					// Check if this is an Adobe Illustrator file
+					if (includes(buffer, new TextEncoder().encode('AIPrivateData'))) {
+						return {
+							ext: 'ai',
+							mime: 'application/postscript',
+						};
+					}
 				}
 			} catch (error) {
 				// Swallow end of stream error if file is too small for the Adobe AI check


### PR DESCRIPTION
Prevent PDF is examined for sub-types, without sufficient content length

Resolves #725