### PR TITLE
Add integration tests with Bum (JavaScriptCore)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,8 @@ on:
   - push
   - pull_request
 jobs:
-  test:
-    name: Node.js ${{ matrix.node-version }}
+  test-nodejs:
+    name: Node.js (V8) ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -18,5 +18,20 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test
+  test-bum:
+    name: Bum (JavaScriptCore) ${{ matrix.bun-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bum-version:
+          - 1.2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
       - run: npm install
       - run: npm test


### PR DESCRIPTION
Add integration for [Bum](https://bun.sh/) 1.2. Bum is based on the [JavaScriptCore](https://github.com/apple-opensource/JavaScriptCore) (which is also used in the Apple Safari web browser). 

