### PR TITLE
[WIP] make js / d.ts files consistent

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -23,65 +23,9 @@ export type FileTypeResult = {
 	readonly mime: string;
 };
 
-/**
-Detect the file type of a `Uint8Array`, or `ArrayBuffer`.
-
-The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
-
-If file access is available, it is recommended to use `.fromFile()` instead.
-
-@param buffer - An Uint8Array or ArrayBuffer representing file data. It works best if the buffer contains the entire file. It may work with a smaller portion as well.
-@returns The detected file type, or `undefined` when there is no match.
-*/
-export function fileTypeFromBuffer(buffer: Uint8Array | ArrayBuffer): Promise<FileTypeResult | undefined>;
-
-/**
-Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
-
-The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
-
-@param stream - A [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
-@returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
-*/
-export function fileTypeFromStream(stream: AnyWebByteStream): Promise<FileTypeResult | undefined>;
-
-/**
-Detect the file type from an [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer) source.
-
-This method is used internally, but can also be used for a special "tokenizer" reader.
-
-A tokenizer propagates the internal read functions, allowing alternative transport mechanisms, to access files, to be implemented and used.
-
-@param tokenizer - File source implementing the tokenizer interface.
-@returns The detected file type, or `undefined` when there is no match.
-
-An example is [`@tokenizer/http`](https://github.com/Borewit/tokenizer-http), which requests data using [HTTP-range-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests). A difference with a conventional stream and the [*tokenizer*](https://github.com/Borewit/strtok3#tokenizer), is that it is able to *ignore* (seek, fast-forward) in the stream. For example, you may only need and read the first 6 bytes, and the last 128 bytes, which may be an advantage in case reading the entire file would take longer.
-
-@example
-```
-import {makeTokenizer} from '@tokenizer/http';
-import {fileTypeFromTokenizer} from 'file-type';
-
-const audioTrackUrl = 'https://test-audio.netlify.com/Various%20Artists%20-%202009%20-%20netBloc%20Vol%2024_%20tiuqottigeloot%20%5BMP3-V2%5D/01%20-%20Diablo%20Swing%20Orchestra%20-%20Heroines.mp3';
-
-const httpTokenizer = await makeTokenizer(audioTrackUrl);
-const fileType = await fileTypeFromTokenizer(httpTokenizer);
-
-console.log(fileType);
-//=> {ext: 'mp3', mime: 'audio/mpeg'}
-```
-*/
-export function fileTypeFromTokenizer(tokenizer: ITokenizer): Promise<FileTypeResult | undefined>;
-
-/**
-Supported file extensions.
-*/
-export const supportedExtensions: ReadonlySet<string>;
-
-/**
-Supported MIME types.
-*/
-export const supportedMimeTypes: ReadonlySet<string>;
+export type AnyWebReadableByteStreamWithFileType = AnyWebReadableStream<Uint8Array> & {
+	readonly fileType?: FileTypeResult;
+};
 
 export type StreamOptions = {
 	/**
@@ -91,27 +35,6 @@ export type StreamOptions = {
 	*/
 	readonly sampleSize?: number;
 };
-
-/**
-Detect the file type of a [`Blob`](https://nodejs.org/api/buffer.html#class-blob) or [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File).
-
-@param blob - The [`Blob`](https://nodejs.org/api/buffer.html#class-blob) used for file detection.
-@returns The detected file type, or `undefined` when there is no match.
-
-@example
-```
-import {fileTypeFromBlob} from 'file-type';
-
-const blob = new Blob(['<?xml version="1.0" encoding="ISO-8859-1" ?>'], {
-	type: 'text/plain',
-	endings: 'native'
-});
-
-console.log(await fileTypeFromBlob(blob));
-//=> {ext: 'txt', mime: 'text/plain'}
-```
-*/
-export declare function fileTypeFromBlob(blob: Blob): Promise<FileTypeResult | undefined>;
 
 /**
 A custom file type detector.
@@ -171,13 +94,76 @@ export type FileTypeOptions = {
 	customDetectors?: Iterable<Detector>;
 };
 
-export declare class TokenizerPositionError extends Error {
-	constructor(message?: string);
-}
+/**
+Detect the file type of a `Uint8Array`, or `ArrayBuffer`.
 
-export type AnyWebReadableByteStreamWithFileType = AnyWebReadableStream<Uint8Array> & {
-	readonly fileType?: FileTypeResult;
-};
+The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
+
+If file access is available, it is recommended to use `.fromFile()` instead.
+
+@param buffer - An Uint8Array or ArrayBuffer representing file data. It works best if the buffer contains the entire file. It may work with a smaller portion as well.
+@returns The detected file type, or `undefined` when there is no match.
+*/
+export function fileTypeFromBuffer(buffer: Uint8Array | ArrayBuffer): Promise<FileTypeResult | undefined>;
+
+/**
+Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+
+The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
+
+@param stream - A [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
+@returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
+*/
+export function fileTypeFromStream(stream: AnyWebByteStream): Promise<FileTypeResult | undefined>;
+
+/**
+Detect the file type of a [`Blob`](https://nodejs.org/api/buffer.html#class-blob) or [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File).
+
+@param blob - The [`Blob`](https://nodejs.org/api/buffer.html#class-blob) used for file detection.
+@returns The detected file type, or `undefined` when there is no match.
+
+@example
+```
+import {fileTypeFromBlob} from 'file-type';
+
+const blob = new Blob(['<?xml version="1.0" encoding="ISO-8859-1" ?>'], {
+	type: 'text/plain',
+	endings: 'native'
+});
+
+console.log(await fileTypeFromBlob(blob));
+//=> {ext: 'txt', mime: 'text/plain'}
+```
+*/
+export declare function fileTypeFromBlob(blob: Blob): Promise<FileTypeResult | undefined>;
+
+/**
+Detect the file type from an [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer) source.
+
+This method is used internally, but can also be used for a special "tokenizer" reader.
+
+A tokenizer propagates the internal read functions, allowing alternative transport mechanisms, to access files, to be implemented and used.
+
+@param tokenizer - File source implementing the tokenizer interface.
+@returns The detected file type, or `undefined` when there is no match.
+
+An example is [`@tokenizer/http`](https://github.com/Borewit/tokenizer-http), which requests data using [HTTP-range-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests). A difference with a conventional stream and the [*tokenizer*](https://github.com/Borewit/strtok3#tokenizer), is that it is able to *ignore* (seek, fast-forward) in the stream. For example, you may only need and read the first 6 bytes, and the last 128 bytes, which may be an advantage in case reading the entire file would take longer.
+
+@example
+```
+import {makeTokenizer} from '@tokenizer/http';
+import {fileTypeFromTokenizer} from 'file-type';
+
+const audioTrackUrl = 'https://test-audio.netlify.com/Various%20Artists%20-%202009%20-%20netBloc%20Vol%2024_%20tiuqottigeloot%20%5BMP3-V2%5D/01%20-%20Diablo%20Swing%20Orchestra%20-%20Heroines.mp3';
+
+const httpTokenizer = await makeTokenizer(audioTrackUrl);
+const fileType = await fileTypeFromTokenizer(httpTokenizer);
+
+console.log(fileType);
+//=> {ext: 'mp3', mime: 'audio/mpeg'}
+```
+*/
+export function fileTypeFromTokenizer(tokenizer: ITokenizer): Promise<FileTypeResult | undefined>;
 
 /**
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
@@ -186,6 +172,19 @@ This method can be handy to put in a stream pipeline, but it comes with a price.
 */
 export function fileTypeStream(webStream: AnyWebReadableStream<Uint8Array>, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 
+/**
+Supported file extensions.
+*/
+export const supportedExtensions: ReadonlySet<string>;
+
+/**
+Supported MIME types.
+*/
+export const supportedMimeTypes: ReadonlySet<string>;
+
+export declare class TokenizerPositionError extends Error {
+	constructor(message?: string);
+}
 export declare class FileTypeParser {
 	/**
 	File type detectors.
@@ -194,7 +193,7 @@ export declare class FileTypeParser {
 	*/
 	detectors: Detector[];
 
-	constructor(options?: {customDetectors?: Iterable<Detector>; signal?: AbortSignal});
+	constructor(options?: FileTypeOptions & {signal?: AbortSignal});
 
 	/**
 	Works the same way as {@link fileTypeFromBuffer}, additionally taking into account custom detectors (if any were provided to the constructor).

--- a/core.js
+++ b/core.js
@@ -15,17 +15,28 @@ import {extensions, mimeTypes} from './supported.js';
 
 export const reasonableDetectionSizeInBytes = 4100; // A fair amount of file-types are detectable within this range.
 
-export async function fileTypeFromStream(stream) {
-	return new FileTypeParser().fromStream(stream);
-}
-
 export async function fileTypeFromBuffer(input) {
 	return new FileTypeParser().fromBuffer(input);
+}
+
+export async function fileTypeFromStream(stream) {
+	return new FileTypeParser().fromStream(stream);
 }
 
 export async function fileTypeFromBlob(blob) {
 	return new FileTypeParser().fromBlob(blob);
 }
+
+export async function fileTypeFromTokenizer(tokenizer) {
+	return new FileTypeParser().fromTokenizer(tokenizer);
+}
+
+export async function fileTypeStream(webStream, options) {
+	return new FileTypeParser().toDetectionStream(webStream, options);
+}
+
+export const supportedExtensions = new Set(extensions);
+export const supportedMimeTypes = new Set(mimeTypes);
 
 function getFileTypeFromMimeType(mimeType) {
 	switch (mimeType) {
@@ -167,14 +178,6 @@ function _check(buffer, headers, options) {
 	}
 
 	return true;
-}
-
-export async function fileTypeFromTokenizer(tokenizer) {
-	return new FileTypeParser().fromTokenizer(tokenizer);
-}
-
-export async function fileTypeStream(webStream, options) {
-	return new FileTypeParser(options).toDetectionStream(webStream, options);
 }
 
 export class FileTypeParser {
@@ -1806,6 +1809,3 @@ export class FileTypeParser {
 		}
 	}
 }
-
-export const supportedExtensions = new Set(extensions);
-export const supportedMimeTypes = new Set(mimeTypes);

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,6 @@ import {
 	type FileTypeResult,
 	type StreamOptions,
 	type AnyWebReadableStream,
-	type Detector,
 	type AnyWebReadableByteStreamWithFileType,
 	FileTypeParser as DefaultFileTypeParser,
 } from './core.js';
@@ -48,7 +47,7 @@ The file type is detected by checking the [magic number](https://en.wikipedia.or
 
 @returns The detected file type and MIME type or `undefined` when there is no match.
 */
-export function fileTypeFromFile(filePath: string, options?: {customDetectors?: Iterable<Detector>}): Promise<FileTypeResult | undefined>;
+export function fileTypeFromFile(filePath: string): Promise<FileTypeResult | undefined>;
 
 /**
 Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
@@ -91,7 +90,8 @@ if (stream2.fileType?.mime === 'image/jpeg') {
 }
 ```
 */
-export function fileTypeStream(readableStream: NodeReadableStream, options?: StreamOptions): Promise<ReadableStreamWithFileType>;
-export function fileTypeStream(webStream: AnyWebByteStream, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
+export function fileTypeStream(readableStream: NodeReadableStream, streamOptiopns?: StreamOptions): Promise<ReadableStreamWithFileType>;
+
+export function fileTypeStream(webStream: AnyWebByteStream,	streamOptiopns?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 
 export * from './core.js';

--- a/index.js
+++ b/index.js
@@ -65,16 +65,16 @@ export class FileTypeParser extends DefaultFileTypeParser {
 	}
 }
 
-export async function fileTypeFromFile(path, fileTypeOptions) {
-	return (new FileTypeParser(fileTypeOptions)).fromFile(path, fileTypeOptions);
+export async function fileTypeFromFile(path) {
+	return (new FileTypeParser()).fromFile(path);
 }
 
-export async function fileTypeFromStream(stream, fileTypeOptions) {
-	return (new FileTypeParser(fileTypeOptions)).fromStream(stream);
+export async function fileTypeFromStream(stream) {
+	return (new FileTypeParser()).fromStream(stream);
 }
 
 export async function fileTypeStream(readableStream, options = {}) {
-	return new FileTypeParser(options).toDetectionStream(readableStream, options);
+	return new FileTypeParser().toDetectionStream(readableStream, options);
 }
 
 export {


### PR DESCRIPTION
It's a WIP related #715

As per https://github.com/sindresorhus/file-type/issues/715#issuecomment-2596421250 , I've removed all the FileTypeOptions arguments passed in helper functions `fileTypeFromXXX`.
Some tests are now failing, it emphasizes the fact that some functions currently have the ability to take a FileTypeOptions argument but not others.

I've also reorganized a bit the file structure of core.js/core.d.ts and index.js/index.d.ts  to make them more or less aligned.

Please let me know if that makes sense, and what would you do about the "helpers" functions, make all of them or none of them able to take FileTypeOptions argument.
