### PR TITLE
Allow `require` to load file-type as ES Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,16 +15,19 @@
 		".": {
 			"node": {
 				"types": "./index.d.ts",
-				"import": "./index.js"
+				"import": "./index.js",
+				"module-sync": "./index.js"
 			},
 			"default": {
 				"types": "./core.d.ts",
-				"import": "./core.js"
+				"import": "./core.js",
+				"module-sync": "./core.js"
 			}
 		},
 		"./core": {
 			"types": "./core.d.ts",
-			"import": "./core.js"
+			"import": "./core.js",
+			"module-sync": "./core.js"
 		}
 	},
 	"sideEffects": false,


### PR DESCRIPTION
Add [`module-sync`](https://nodejs.org/api/packages.html#conditional-exports) in exports, allowing [require-esm loading](https://joyeecheung.github.io/blog/2024/03/18/require-esm-in-node-js) **file-type** with Node.js ≥ 22.
 
Discussion: https://github.com/sindresorhus/file-type/pull/722#issuecomment-2645592908

Superseding:
- #722
- #723. 

Related:
- #665
- #696
- #671
- #668
- #661
- #600

