### PR TITLE
Add './node' subpath export for node entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,16 +15,19 @@
 		".": {
 			"node": {
 				"types": "./index.d.ts",
-				"import": "./index.js"
+				"import": "./index.js",
+				"module-sync": "./index.js"
 			},
 			"default": {
 				"types": "./core.d.ts",
-				"import": "./core.js"
+				"import": "./core.js",
+				"module-sync": "./core.js"
 			}
 		},
 		"./core": {
 			"types": "./core.d.ts",
-			"import": "./core.js"
+			"import": "./core.js",
+			"module-sync": "./core.js"
 		}
 	},
 	"sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -26,8 +26,11 @@
 		},
 		"./core": {
 			"types": "./core.d.ts",
-			"import": "./core.js",
-			"module-sync": "./core.js"
+			"default": "./core.js"
+		},
+		"./node": {
+			"types": "./index.d.ts",
+			"default": "./index.js"
 		}
 	},
 	"sideEffects": false,


### PR DESCRIPTION
Add `./node` subpath export

`./core` has been inherited at the days this package was CJS, where the default exports was Node.js. The core allowed to import the functionality, which did not depend on the Node API. With ES Module implementation, it is the other way around. The non-Node is now the default. Therefor it make more sense expose the Node specific functionality, for those cases where conditional exports cannot be used. Such as the ``"moduleResolution": "bundler"` in TypeScript projects.

I chose to use the `default` export in this case  _as generic fallback that always matches_, as the subpath import is the user overruling the import in cases where the conditional imports have no, or not the desired effect.  

Fixes #652
Fixes #738