### PR TITLE
The following workaround prevents TypeScript using "bundler" throwing…

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -195,8 +195,8 @@ export type AnyWebReadableByteStreamWithFileType = AnyWebReadableStream<Uint8Arr
 };
 
 /**
-  Workaround for TypeScript using "bundler" as the module-resolution.
- */
+Workaround for using `bundler` as the module-resolution in TypeScript.
+*/
 export function fileTypeFromFile(filePath: string, options?: {customDetectors?: Iterable<Detector>}): Promise<FileTypeResult | undefined>;
 
 /**

--- a/core.d.ts
+++ b/core.d.ts
@@ -195,6 +195,11 @@ export type AnyWebReadableByteStreamWithFileType = AnyWebReadableStream<Uint8Arr
 };
 
 /**
+  Workaround for TypeScript using "bundler" as the module-resolution.
+ */
+export function fileTypeFromFile(filePath: string, options?: {customDetectors?: Iterable<Detector>}): Promise<FileTypeResult | undefined>;
+
+/**
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
 
 This method can be handy to put in a stream pipeline, but it comes with a price. Internally `stream()` builds up a buffer of `sampleSize` bytes, used as a sample, to determine the file type. The sample size impacts the file detection resolution. A smaller sample size will result in lower probability of the best file type detection.


### PR DESCRIPTION
The following workaround prevents TypeScript using "bundler" throwing compilation errors, fileTypeFromFile, does not exist.

Unlike requiring to import `/node` or set the node condition in the TypeScript compiler configuration, this one works out of the box.

Also raised issue where it comes from: 
- https://github.com/microsoft/TypeScript/issues/61357 

Related to #741
Fixes https://github.com/sindresorhus/file-type/issues/652
