### PR TITLE
fix: official IANA MIME type for Apache Parquet files

### DIFF
--- a/core.js
+++ b/core.js
@@ -920,7 +920,7 @@ export class FileTypeParser {
 			};
 		}
 
-		if (this.checkString('PAR1')) {
+		if (this.checkString('PAR1') || this.checkString('PARE')) {
 			return {
 				ext: 'parquet',
 				mime: 'application/vnd.apache.parquet',

--- a/core.js
+++ b/core.js
@@ -923,7 +923,7 @@ export class FileTypeParser {
 		if (this.checkString('PAR1')) {
 			return {
 				ext: 'parquet',
-				mime: 'application/x-parquet',
+				mime: 'application/vnd.apache.parquet',
 			};
 		}
 

--- a/supported.js
+++ b/supported.js
@@ -321,7 +321,7 @@ export const mimeTypes = [
 	'image/jls',
 	'application/vnd.ms-outlook',
 	'image/vnd.dwg',
-	'application/x-parquet',
+	'application/vnd.apache.parquet',
 	'application/java-vm',
 	'application/x-arj',
 	'application/x-cpio',


### PR DESCRIPTION
The MIME type 'application/x-parquet' is old/deprecated/unofficial. The official MIME type is: `application/vnd.apache.parquet`.
Also added a missing magic number for this type.

https://www.iana.org/assignments/media-types/application/vnd.apache.parquet

If you're adding support for a new file type, please follow the below steps:

- **One PR per file type.**
- [x] Add the file's MIME type to the `types` array in `supported.js`.
- [x] Add the file type detection logic to the `core.js` file.
