### PR TITLE
Allow file-type options to be directly passed to exported functions

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -37,7 +37,7 @@ If file access is available, it is recommended to use `.fromFile()` instead.
 export function fileTypeFromBuffer(buffer: Uint8Array | ArrayBuffer, options?: FileTypeOptions): Promise<FileTypeResult | undefined>;
 
 /**
-Detect the file type of [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 

--- a/core.d.ts
+++ b/core.d.ts
@@ -24,38 +24,38 @@ export type FileTypeResult = {
 };
 
 /**
-Detect the file type of a `Uint8Array`, or `ArrayBuffer`.
+Detect the file type of `Uint8Array`, or `ArrayBuffer`.
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
 If file access is available, it is recommended to use `.fromFile()` instead.
 
 @param buffer - An Uint8Array or ArrayBuffer representing file data. It works best if the buffer contains the entire file. It may work with a smaller portion as well.
-@param options - Options to override default behaviour.
+@param options - Options to override default behavior.
 @returns The detected file type, or `undefined` when there is no match.
 */
 export function fileTypeFromBuffer(buffer: Uint8Array | ArrayBuffer, options?: FileTypeOptions): Promise<FileTypeResult | undefined>;
 
 /**
-Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+Detect the file type of [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
 @param stream - A [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
-@param options - Options to override default behaviour.
+@param options - Options to override default behavior.
 @returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
 */
 export function fileTypeFromStream(stream: AnyWebByteStream, options?: FileTypeOptions): Promise<FileTypeResult | undefined>;
 
 /**
-Detect the file type from an [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer) source.
+Detect the file type from [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer) source.
 
 This method is used internally, but can also be used for a special "tokenizer" reader.
 
 A tokenizer propagates the internal read functions, allowing alternative transport mechanisms, to access files, to be implemented and used.
 
 @param tokenizer - File source implementing the tokenizer interface.
-@param options - Options to override default behaviour.
+@param options - Options to override default behavior.
 @returns The detected file type, or `undefined` when there is no match.
 
 An example is [`@tokenizer/http`](https://github.com/Borewit/tokenizer-http), which requests data using [HTTP-range-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests). A difference with a conventional stream and the [*tokenizer*](https://github.com/Borewit/strtok3#tokenizer), is that it is able to *ignore* (seek, fast-forward) in the stream. For example, you may only need and read the first 6 bytes, and the last 128 bytes, which may be an advantage in case reading the entire file would take longer.
@@ -99,7 +99,7 @@ export type StreamOptions = {
 Detect the file type of a [`Blob`](https://nodejs.org/api/buffer.html#class-blob) or [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File).
 
 @param blob - The [`Blob`](https://nodejs.org/api/buffer.html#class-blob) used for file detection.
-@param options - Options to override default behaviour.
+@param options - Options to override default behavior.
 @returns The detected file type, or `undefined` when there is no match.
 
 @example

--- a/core.d.ts
+++ b/core.d.ts
@@ -24,7 +24,7 @@ export type FileTypeResult = {
 };
 
 /**
-Detect the file type of `Uint8Array`, or `ArrayBuffer`.
+Detect the file type of a `Uint8Array` or `ArrayBuffer`.
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
@@ -48,7 +48,7 @@ The file type is detected by checking the [magic number](https://en.wikipedia.or
 export function fileTypeFromStream(stream: AnyWebByteStream, options?: FileTypeOptions): Promise<FileTypeResult | undefined>;
 
 /**
-Detect the file type from [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer) source.
+Detect the file type from an [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer) source.
 
 This method is used internally, but can also be used for a special "tokenizer" reader.
 

--- a/core.d.ts
+++ b/core.d.ts
@@ -31,9 +31,10 @@ The file type is detected by checking the [magic number](https://en.wikipedia.or
 If file access is available, it is recommended to use `.fromFile()` instead.
 
 @param buffer - An Uint8Array or ArrayBuffer representing file data. It works best if the buffer contains the entire file. It may work with a smaller portion as well.
+@param options - Options to override default behaviour.
 @returns The detected file type, or `undefined` when there is no match.
 */
-export function fileTypeFromBuffer(buffer: Uint8Array | ArrayBuffer): Promise<FileTypeResult | undefined>;
+export function fileTypeFromBuffer(buffer: Uint8Array | ArrayBuffer, options?: FileTypeOptions): Promise<FileTypeResult | undefined>;
 
 /**
 Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
@@ -41,9 +42,10 @@ Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/e
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
 @param stream - A [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) streaming a file to examine.
+@param options - Options to override default behaviour.
 @returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
 */
-export function fileTypeFromStream(stream: AnyWebByteStream): Promise<FileTypeResult | undefined>;
+export function fileTypeFromStream(stream: AnyWebByteStream, options?: FileTypeOptions): Promise<FileTypeResult | undefined>;
 
 /**
 Detect the file type from an [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer) source.
@@ -53,6 +55,7 @@ This method is used internally, but can also be used for a special "tokenizer" r
 A tokenizer propagates the internal read functions, allowing alternative transport mechanisms, to access files, to be implemented and used.
 
 @param tokenizer - File source implementing the tokenizer interface.
+@param options - Options to override default behaviour.
 @returns The detected file type, or `undefined` when there is no match.
 
 An example is [`@tokenizer/http`](https://github.com/Borewit/tokenizer-http), which requests data using [HTTP-range-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests). A difference with a conventional stream and the [*tokenizer*](https://github.com/Borewit/strtok3#tokenizer), is that it is able to *ignore* (seek, fast-forward) in the stream. For example, you may only need and read the first 6 bytes, and the last 128 bytes, which may be an advantage in case reading the entire file would take longer.
@@ -71,7 +74,7 @@ console.log(fileType);
 //=> {ext: 'mp3', mime: 'audio/mpeg'}
 ```
 */
-export function fileTypeFromTokenizer(tokenizer: ITokenizer): Promise<FileTypeResult | undefined>;
+export function fileTypeFromTokenizer(tokenizer: ITokenizer, options?: FileTypeOptions): Promise<FileTypeResult | undefined>;
 
 /**
 Supported file extensions.
@@ -96,6 +99,7 @@ export type StreamOptions = {
 Detect the file type of a [`Blob`](https://nodejs.org/api/buffer.html#class-blob) or [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File).
 
 @param blob - The [`Blob`](https://nodejs.org/api/buffer.html#class-blob) used for file detection.
+@param options - Options to override default behaviour.
 @returns The detected file type, or `undefined` when there is no match.
 
 @example
@@ -111,7 +115,7 @@ console.log(await fileTypeFromBlob(blob));
 //=> {ext: 'txt', mime: 'text/plain'}
 ```
 */
-export declare function fileTypeFromBlob(blob: Blob): Promise<FileTypeResult | undefined>;
+export declare function fileTypeFromBlob(blob: Blob, options?: FileTypeOptions): Promise<FileTypeResult | undefined>;
 
 /**
 A custom file type detector.

--- a/core.js
+++ b/core.js
@@ -15,16 +15,16 @@ import {extensions, mimeTypes} from './supported.js';
 
 export const reasonableDetectionSizeInBytes = 4100; // A fair amount of file-types are detectable within this range.
 
-export async function fileTypeFromStream(stream) {
-	return new FileTypeParser().fromStream(stream);
+export async function fileTypeFromStream(stream, options) {
+	return new FileTypeParser(options).fromStream(stream);
 }
 
-export async function fileTypeFromBuffer(input) {
-	return new FileTypeParser().fromBuffer(input);
+export async function fileTypeFromBuffer(input, options) {
+	return new FileTypeParser(options).fromBuffer(input);
 }
 
-export async function fileTypeFromBlob(blob) {
-	return new FileTypeParser().fromBlob(blob);
+export async function fileTypeFromBlob(blob, options) {
+	return new FileTypeParser(options).fromBlob(blob);
 }
 
 function getFileTypeFromMimeType(mimeType) {
@@ -180,8 +180,8 @@ function _check(buffer, headers, options) {
 	return true;
 }
 
-export async function fileTypeFromTokenizer(tokenizer) {
-	return new FileTypeParser().fromTokenizer(tokenizer);
+export async function fileTypeFromTokenizer(tokenizer, options) {
+	return new FileTypeParser(options).fromTokenizer(tokenizer);
 }
 
 export async function fileTypeStream(webStream, options) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,8 +31,8 @@ export declare class FileTypeParser extends DefaultFileTypeParser {
 	/**
 	Works the same way as {@link fileTypeStream}, additionally taking into account custom detectors (if any were provided to the constructor).
 	*/
-	toDetectionStream(readableStream: NodeReadableStream, options?: StreamOptions): Promise<ReadableStreamWithFileType>;
-	toDetectionStream(webStream: AnyWebReadableStream<Uint8Array>, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
+	toDetectionStream(readableStream: NodeReadableStream, options?: FileTypeOptions & StreamOptions): Promise<ReadableStreamWithFileType>;
+	toDetectionStream(webStream: AnyWebReadableStream<Uint8Array>, options?: FileTypeOptions & StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 }
 
 /**
@@ -92,7 +92,7 @@ if (stream2.fileType?.mime === 'image/jpeg') {
 }
 ```
 */
-export function fileTypeStream(readableStream: NodeReadableStream, options?: StreamOptions | FileTypeOptions): Promise<ReadableStreamWithFileType>;
-export function fileTypeStream(webStream: AnyWebByteStream, options?: StreamOptions | FileTypeOptions): Promise<AnyWebReadableByteStreamWithFileType>;
+export function fileTypeStream(readableStream: NodeReadableStream, options?: FileTypeOptions & StreamOptions): Promise<ReadableStreamWithFileType>;
+export function fileTypeStream(webStream: AnyWebByteStream, options?: FileTypeOptions & StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 
 export * from './core.js';

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,8 +8,8 @@ import {
 	type FileTypeResult,
 	type StreamOptions,
 	type AnyWebReadableStream,
-	type Detector,
 	type AnyWebReadableByteStreamWithFileType,
+	type FileTypeOptions,
 	FileTypeParser as DefaultFileTypeParser,
 } from './core.js';
 
@@ -48,7 +48,7 @@ The file type is detected by checking the [magic number](https://en.wikipedia.or
 
 @returns The detected file type and MIME type or `undefined` when there is no match.
 */
-export function fileTypeFromFile(filePath: string, options?: {customDetectors?: Iterable<Detector>}): Promise<FileTypeResult | undefined>;
+export function fileTypeFromFile(filePath: string, options?: FileTypeOptions): Promise<FileTypeResult | undefined>;
 
 /**
 Detect the file type of a [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
@@ -60,9 +60,10 @@ Direct support for Node.js streams will be dropped in the future, when Node.js s
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
 @param stream - A [web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [Node.js `stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable) streaming a file to examine.
-@returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
+@param options - Options to override default behaviour.
+ @returns A `Promise` for an object with the detected file type, or `undefined` when there is no match.
 */
-export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream): Promise<FileTypeResult | undefined>;
+export function fileTypeFromStream(stream: AnyWebReadableStream<Uint8Array> | NodeReadableStream, options?: FileTypeOptions): Promise<FileTypeResult | undefined>;
 
 /**
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
@@ -91,7 +92,7 @@ if (stream2.fileType?.mime === 'image/jpeg') {
 }
 ```
 */
-export function fileTypeStream(readableStream: NodeReadableStream, options?: StreamOptions): Promise<ReadableStreamWithFileType>;
-export function fileTypeStream(webStream: AnyWebByteStream, options?: StreamOptions): Promise<AnyWebReadableByteStreamWithFileType>;
+export function fileTypeStream(readableStream: NodeReadableStream, options?: StreamOptions | FileTypeOptions): Promise<ReadableStreamWithFileType>;
+export function fileTypeStream(webStream: AnyWebByteStream, options?: StreamOptions | FileTypeOptions): Promise<AnyWebReadableByteStreamWithFileType>;
 
 export * from './core.js';

--- a/index.js
+++ b/index.js
@@ -65,12 +65,12 @@ export class FileTypeParser extends DefaultFileTypeParser {
 	}
 }
 
-export async function fileTypeFromFile(path, fileTypeOptions) {
-	return (new FileTypeParser(fileTypeOptions)).fromFile(path, fileTypeOptions);
+export async function fileTypeFromFile(path, options) {
+	return (new FileTypeParser(options)).fromFile(path, options);
 }
 
-export async function fileTypeFromStream(stream, fileTypeOptions) {
-	return (new FileTypeParser(fileTypeOptions)).fromStream(stream);
+export async function fileTypeFromStream(stream, options) {
+	return (new FileTypeParser(options)).fromStream(stream);
 }
 
 export async function fileTypeStream(readableStream, options = {}) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,8 @@
 import {createReadStream} from 'node:fs';
+import {Readable} from 'node:stream';
+import {ReadableStream as NodeReadableStream} from 'node:stream/web';
 import {expectType} from 'tsd';
+import {fromFile} from 'strtok3';
 import {
 	type FileTypeResult as FileTypeResultBrowser,
 } from './core.js';
@@ -13,19 +16,35 @@ import {
 	supportedMimeTypes,
 	type FileTypeResult,
 	type ReadableStreamWithFileType,
+	FileTypeParser,
 } from './index.js';
 
 expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new Uint8Array([0xFF, 0xD8, 0xFF])));
 expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuffer(42)));
 
+// FileTypeFromBuffer
 (async () => {
 	const result = await fileTypeFromBuffer(new Uint8Array([0xFF, 0xD8, 0xFF]));
 	if (result !== undefined) {
 		expectType<string>(result.ext);
 		expectType<string>(result.mime);
 	}
+
+	expectType<FileTypeResult | undefined>(await fileTypeFromBuffer(new Uint8Array([0xFF, 0xD8, 0xFF]), {customDetectors: []}));
 })();
 
+// FileTypeFromBlob
+(async () => {
+	const result = await fileTypeFromBlob(new Blob());
+	if (result !== undefined) {
+		expectType<string>(result.ext);
+		expectType<string>(result.mime);
+	}
+
+	expectType<FileTypeResult | undefined>(await fileTypeFromBlob(new Blob(), {customDetectors: []}));
+})();
+
+// FileTypeFromFile
 (async () => {
 	expectType<FileTypeResult | undefined>(await fileTypeFromFile('myFile'));
 
@@ -34,8 +53,11 @@ expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuff
 		expectType<string>(result.ext);
 		expectType<string>(result.mime);
 	}
+
+	expectType<FileTypeResult | undefined>(await fileTypeFromFile('myFile', {customDetectors: []}));
 })();
 
+// FileTypeFromStream
 (async () => {
 	const stream = createReadStream('myFile');
 
@@ -46,6 +68,66 @@ expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuff
 		expectType<string>(result.ext);
 		expectType<string>(result.mime);
 	}
+
+	expectType<FileTypeResult | undefined>(await fileTypeFromStream(stream, {customDetectors: []}));
+})();
+
+// ToDetectionStream
+(async () => {
+	const inputReadable = createReadStream('myFile');
+
+	// Basic usage
+	const result = await fileTypeStream(inputReadable);
+	expectType<ReadableStreamWithFileType>(result);
+	expectType<FileTypeResult | undefined>(result.fileType);
+
+	// With FileTypeOptions
+	expectType<ReadableStreamWithFileType>(await fileTypeStream(inputReadable, {customDetectors: []}));
+
+	// With StreamOptions
+	expectType<ReadableStreamWithFileType>(await fileTypeStream(inputReadable, {sampleSize: 256}));
+
+	// With StreamOptions & FileTypeOptions
+	expectType<ReadableStreamWithFileType>(await fileTypeStream(inputReadable, {sampleSize: 256, customDetectors: []}));
+})();
+
+// Test typings file-type class FileTypeParser
+(async () => {
+	// No arguments provided to constructor
+	let fileTypeParser = new FileTypeParser();
+	// With custom detectors
+	fileTypeParser = new FileTypeParser({customDetectors: []});
+
+	const fromFileFileType = await fileTypeParser.fromFile('myFile');
+	expectType<FileTypeResult | undefined>(fromFileFileType);
+
+	// From a Node Readable (stream)
+	const fromNodeStreamFileType = await fileTypeParser.fromStream(new Readable());
+	expectType<FileTypeResult | undefined>(fromNodeStreamFileType);
+
+	// From a DOM type Blob
+	const fromBlobFileType = await fileTypeParser.fromBlob(new Blob());
+	expectType<FileTypeResult | undefined>(fromBlobFileType);
+
+	// From a DOM type Web byte ReadableStream
+	const fromWebReadableStreamFileType = await fileTypeParser.fromStream(new ReadableStream({type: 'bytes'}));
+	expectType<FileTypeResult | undefined>(fromWebReadableStreamFileType);
+
+	// From a Node type byte ReadableStream
+	const fromNodeReadableStreamFileType = await fileTypeParser.fromStream(new NodeReadableStream({type: 'bytes'}));
+	expectType<FileTypeResult | undefined>(fromNodeReadableStreamFileType);
+
+	// From a Node type byte ReadableStream
+	const tokenizer = await fromFile('myFile');
+	const fromTokenizerFileType = await fileTypeParser.fromTokenizer(tokenizer);
+	expectType<FileTypeResult | undefined>(fromTokenizerFileType);
+
+	// From a Node type byte ReadableStream
+	const toDetectionStreamReadable = await fileTypeParser.toDetectionStream(new Readable());
+	expectType<ReadableStreamWithFileType>(toDetectionStreamReadable);
+
+	const toDetectionStreamWithOptionsReadable = await fileTypeParser.toDetectionStream(new Readable(), {sampleSize: 256});
+	expectType<ReadableStreamWithFileType>(toDetectionStreamWithOptionsReadable);
 })();
 
 expectType<ReadonlySet<string>>(supportedExtensions);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -35,25 +35,13 @@ expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuff
 
 // FileTypeFromBlob
 (async () => {
-	const result = await fileTypeFromBlob(new Blob());
-	if (result !== undefined) {
-		expectType<string>(result.ext);
-		expectType<string>(result.mime);
-	}
-
+	expectType<FileTypeResult | undefined>(await fileTypeFromBlob(new Blob()));
 	expectType<FileTypeResult | undefined>(await fileTypeFromBlob(new Blob(), {customDetectors: []}));
 })();
 
 // FileTypeFromFile
 (async () => {
 	expectType<FileTypeResult | undefined>(await fileTypeFromFile('myFile'));
-
-	const result = await fileTypeFromFile('myFile');
-	if (result !== undefined) {
-		expectType<string>(result.ext);
-		expectType<string>(result.mime);
-	}
-
 	expectType<FileTypeResult | undefined>(await fileTypeFromFile('myFile', {customDetectors: []}));
 })();
 
@@ -62,13 +50,6 @@ expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuff
 	const stream = createReadStream('myFile');
 
 	expectType<FileTypeResult | undefined>(await fileTypeFromStream(stream));
-
-	const result = await fileTypeFromStream(stream);
-	if (result !== undefined) {
-		expectType<string>(result.ext);
-		expectType<string>(result.mime);
-	}
-
 	expectType<FileTypeResult | undefined>(await fileTypeFromStream(stream, {customDetectors: []}));
 })();
 
@@ -98,36 +79,28 @@ expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuff
 	// With custom detectors
 	fileTypeParser = new FileTypeParser({customDetectors: []});
 
-	const fromFileFileType = await fileTypeParser.fromFile('myFile');
-	expectType<FileTypeResult | undefined>(fromFileFileType);
+	expectType<FileTypeResult | undefined>(await fileTypeParser.fromFile('myFile'));
 
 	// From a Node Readable (stream)
-	const fromNodeStreamFileType = await fileTypeParser.fromStream(new Readable());
-	expectType<FileTypeResult | undefined>(fromNodeStreamFileType);
+	expectType<FileTypeResult | undefined>(await fileTypeParser.fromStream(new Readable()));
 
 	// From a DOM type Blob
-	const fromBlobFileType = await fileTypeParser.fromBlob(new Blob());
-	expectType<FileTypeResult | undefined>(fromBlobFileType);
+	expectType<FileTypeResult | undefined>(await fileTypeParser.fromBlob(new Blob()));
 
 	// From a DOM type Web byte ReadableStream
-	const fromWebReadableStreamFileType = await fileTypeParser.fromStream(new ReadableStream({type: 'bytes'}));
-	expectType<FileTypeResult | undefined>(fromWebReadableStreamFileType);
+	expectType<FileTypeResult | undefined>(await fileTypeParser.fromStream(new ReadableStream({type: 'bytes'})));
 
 	// From a Node type byte ReadableStream
-	const fromNodeReadableStreamFileType = await fileTypeParser.fromStream(new NodeReadableStream({type: 'bytes'}));
-	expectType<FileTypeResult | undefined>(fromNodeReadableStreamFileType);
+	expectType<FileTypeResult | undefined>(await fileTypeParser.fromStream(new NodeReadableStream({type: 'bytes'})));
 
 	// From a Node type byte ReadableStream
 	const tokenizer = await fromFile('myFile');
-	const fromTokenizerFileType = await fileTypeParser.fromTokenizer(tokenizer);
-	expectType<FileTypeResult | undefined>(fromTokenizerFileType);
+	expectType<FileTypeResult | undefined>(await fileTypeParser.fromTokenizer(tokenizer));
 
 	// From a Node type byte ReadableStream
-	const toDetectionStreamReadable = await fileTypeParser.toDetectionStream(new Readable());
-	expectType<ReadableStreamWithFileType>(toDetectionStreamReadable);
+	expectType<ReadableStreamWithFileType>(await fileTypeParser.toDetectionStream(new Readable()));
 
-	const toDetectionStreamWithOptionsReadable = await fileTypeParser.toDetectionStream(new Readable(), {sampleSize: 256});
-	expectType<ReadableStreamWithFileType>(toDetectionStreamWithOptionsReadable);
+	expectType<ReadableStreamWithFileType>(await fileTypeParser.toDetectionStream(new Readable(), {sampleSize: 256}));
 })();
 
 expectType<ReadonlySet<string>>(supportedExtensions);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -68,7 +68,7 @@ expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuff
 	// With StreamOptions
 	expectType<ReadableStreamWithFileType>(await fileTypeStream(inputReadable, {sampleSize: 256}));
 
-	// With StreamOptions & FileTypeOptions
+	// Should accept mixed options from: StreamOptions & FileTypeOptions
 	expectType<ReadableStreamWithFileType>(await fileTypeStream(inputReadable, {sampleSize: 256, customDetectors: []}));
 })();
 
@@ -81,17 +81,23 @@ expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuff
 
 	expectType<FileTypeResult | undefined>(await fileTypeParser.fromFile('myFile'));
 
+	// From a Blob
+	expectType<FileTypeResult | undefined>(await fileTypeParser.fromBlob(new Blob()));
+
 	// From a Node Readable (stream)
 	expectType<FileTypeResult | undefined>(await fileTypeParser.fromStream(new Readable()));
 
-	// From a DOM type Blob
-	expectType<FileTypeResult | undefined>(await fileTypeParser.fromBlob(new Blob()));
+	// From a DOM type Web ReadableStream<Uint8Array>
+	expectType<FileTypeResult | undefined>(await fileTypeParser.fromStream(new ReadableStream<Uint8Array>()));
 
 	// From a DOM type Web byte ReadableStream
 	expectType<FileTypeResult | undefined>(await fileTypeParser.fromStream(new ReadableStream({type: 'bytes'})));
 
 	// From a Node type byte ReadableStream
 	expectType<FileTypeResult | undefined>(await fileTypeParser.fromStream(new NodeReadableStream({type: 'bytes'})));
+
+	// From a Node type ReadableStream<Uint8Array>
+	expectType<FileTypeResult | undefined>(await fileTypeParser.fromStream(new NodeReadableStream<Uint8Array>()));
 
 	// From a Node type byte ReadableStream
 	const tokenizer = await fromFile('myFile');
@@ -100,7 +106,8 @@ expectType<Promise<FileTypeResult | undefined>>(fileTypeFromBuffer(new ArrayBuff
 	// From a Node type byte ReadableStream
 	expectType<ReadableStreamWithFileType>(await fileTypeParser.toDetectionStream(new Readable()));
 
-	expectType<ReadableStreamWithFileType>(await fileTypeParser.toDetectionStream(new Readable(), {sampleSize: 256}));
+	// Should accept mixed options from: StreamOptions & FileTypeOptions
+	expectType<ReadableStreamWithFileType>(await fileTypeParser.toDetectionStream(new Readable(), {sampleSize: 256, customDetectors: []}));
 })();
 
 expectType<ReadonlySet<string>>(supportedExtensions);

--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ console.log(fileType);
 
 ## API
 
-### fileTypeFromBuffer(buffer)
+### fileTypeFromBuffer(buffer, options)
 
 Detect the file type of a `Uint8Array`, or `ArrayBuffer`.
 
@@ -130,13 +130,17 @@ Type: `Uint8Array | ArrayBuffer`
 
 A buffer representing file data. It works best if the buffer contains the entire file. It may work with a smaller portion as well.
 
-### fileTypeFromFile(filePath)
+#### options
+
+See [file type-options](#file-type-options).
+
+### fileTypeFromFile(filePath, options)
 
 Detect the file type of a file path.
 
 This is for Node.js only.
 
-To read from a [`File`](https://developer.mozilla.org/docs/Web/API/File), see [`fileTypeFromBlob()`](#filetypefromblobblob).
+To read from a [`File`](https://developer.mozilla.org/docs/Web/API/File), see [`fileTypeFromBlob()`](#filetypefromblobblob-options).
 
 The file type is detected by checking the [magic number](https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files) of the buffer.
 
@@ -152,6 +156,10 @@ Or `undefined` when there is no match.
 Type: `string`
 
 The file path to parse.
+
+#### options
+
+See [file type-options](#file-type-options).
 
 ### fileTypeFromStream(stream)
 
@@ -176,7 +184,7 @@ Type: [Web `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/Re
 
 A readable stream representing file data.
 
-### fileTypeFromBlob(blob)
+### fileTypeFromBlob(blob, options)
 
 Detect the file type of a [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob),
 
@@ -225,7 +233,11 @@ async function readFromBlobWithoutStreaming(blob) {
 
 Type: [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)
 
-### fileTypeFromTokenizer(tokenizer)
+#### options
+
+See [file type-options](#file-type-options).
+
+### fileTypeFromTokenizer(tokenizer, options)
 
 Detect the file type from an `ITokenizer` source.
 
@@ -285,6 +297,10 @@ Type: [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer)
 
 A file source implementing the [tokenizer interface](https://github.com/Borewit/strtok3#tokenizer).
 
+#### options
+
+See [file type-options](#file-type-options).
+
 ### fileTypeStream(webStream, options?)
 
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
@@ -303,6 +319,8 @@ Type: [`stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream
 #### options
 
 Type: `object`
+
+May also include [generic file-type options](#file-type-options).
 
 ##### sampleSize
 
@@ -341,6 +359,19 @@ Returns a `Set<string>` of supported file extensions.
 
 Returns a `Set<string>` of supported MIME types.
 
+### File-type options
+The following optional options are supported:
+
+- `customDetectors`: Array of custom file type detectors, to run before default detectors.
+  For example:
+  ```js
+  import {fileTypeFromFile} from 'file-type';
+  import {detectXml} from '@file-type/xml';
+
+  const fileType = await fileTypeFromFile('sample.kml', {customDetectors: [detectXml]});
+  console.log(fileType);
+  ```
+
 ## Custom detectors
 
 Custom file type detectors are plugins designed to extend the default detection capabilities.
@@ -354,11 +385,10 @@ Detectors can be added via the constructor options or by directly modifying `Fil
 ### Example adding a detector
 
 ```js
-import {FileTypeParser} from 'file-type';
+import {fileTypeFromFile} from 'file-type';
 import {detectXml} from '@file-type/xml';
 
-const parser = new FileTypeParser({customDetectors: [detectXml]});
-const fileType = await parser.fromFile('sample.kml');
+const fileType = await fileTypeFromFile('sample.kml', {customDetectors: [detectXml]});
 console.log(fileType);
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -304,7 +304,7 @@ Type: [`stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream
 
 Type: `object`
 
-May also include [generic file-type options](#options).
+Supports the following options in addition to the [general options](#options):
 
 ##### sampleSize
 

--- a/readme.md
+++ b/readme.md
@@ -130,10 +130,6 @@ Type: `Uint8Array | ArrayBuffer`
 
 A buffer representing file data. It works best if the buffer contains the entire file. It may work with a smaller portion as well.
 
-#### options
-
-See [file type-options](#file-type-options).
-
 ### fileTypeFromFile(filePath, options)
 
 Detect the file type of a file path.
@@ -156,10 +152,6 @@ Or `undefined` when there is no match.
 Type: `string`
 
 The file path to parse.
-
-#### options
-
-See [file type-options](#file-type-options).
 
 ### fileTypeFromStream(stream)
 
@@ -233,10 +225,6 @@ async function readFromBlobWithoutStreaming(blob) {
 
 Type: [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)
 
-#### options
-
-See [file type-options](#file-type-options).
-
 ### fileTypeFromTokenizer(tokenizer, options)
 
 Detect the file type from an `ITokenizer` source.
@@ -297,10 +285,6 @@ Type: [`ITokenizer`](https://github.com/Borewit/strtok3#tokenizer)
 
 A file source implementing the [tokenizer interface](https://github.com/Borewit/strtok3#tokenizer).
 
-#### options
-
-See [file type-options](#file-type-options).
-
 ### fileTypeStream(webStream, options?)
 
 Returns a `Promise` which resolves to the original readable stream argument, but with an added `fileType` property, which is an object like the one returned from `fileTypeFromFile()`.
@@ -360,17 +344,21 @@ Returns a `Set<string>` of supported file extensions.
 Returns a `Set<string>` of supported MIME types.
 
 ### File-type options
+
 The following optional options are supported:
 
-- `customDetectors`: Array of custom file type detectors, to run before default detectors.
-  For example:
-  ```js
-  import {fileTypeFromFile} from 'file-type';
-  import {detectXml} from '@file-type/xml';
+#### customDetectors
 
-  const fileType = await fileTypeFromFile('sample.kml', {customDetectors: [detectXml]});
-  console.log(fileType);
-  ```
+Array of custom file type detectors, to run before default detectors.
+
+For example:
+```js
+import {fileTypeFromFile} from 'file-type';
+import {detectXml} from '@file-type/xml';
+
+const fileType = await fileTypeFromFile('sample.kml', {customDetectors: [detectXml]});
+console.log(fileType);
+```
 
 ## Custom detectors
 
@@ -384,11 +372,13 @@ Detectors can be added via the constructor options or by directly modifying `Fil
 
 ### Example adding a detector
 
+For example:
 ```js
 import {fileTypeFromFile} from 'file-type';
 import {detectXml} from '@file-type/xml';
 
-const fileType = await fileTypeFromFile('sample.kml', {customDetectors: [detectXml]});
+const parser = new FileTypeParser({customDetectors: [detectXml]});
+const fileType = await parser.fromFile('sample.kml');
 console.log(fileType);
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -374,7 +374,7 @@ Detectors can be added via the constructor options or by directly modifying `Fil
 For example:
 
 ```js
-import {fileTypeFromFile} from 'file-type';
+import {FileTypeParser} from 'file-type';
 import {detectXml} from '@file-type/xml';
 
 const parser = new FileTypeParser({customDetectors: [detectXml]});

--- a/readme.md
+++ b/readme.md
@@ -304,7 +304,7 @@ Type: [`stream.Readable`](https://nodejs.org/api/stream.html#stream_class_stream
 
 Type: `object`
 
-May also include [generic file-type options](#file-type-options).
+May also include [generic file-type options](#options).
 
 ##### sampleSize
 
@@ -343,15 +343,14 @@ Returns a `Set<string>` of supported file extensions.
 
 Returns a `Set<string>` of supported MIME types.
 
-### File-type options
-
-The following optional options are supported:
+### Options
 
 #### customDetectors
 
-Array of custom file type detectors, to run before default detectors.
+Array of custom file type detectors to run before default detectors.
 
 For example:
+
 ```js
 import {fileTypeFromFile} from 'file-type';
 import {detectXml} from '@file-type/xml';
@@ -373,6 +372,7 @@ Detectors can be added via the constructor options or by directly modifying `Fil
 ### Example adding a detector
 
 For example:
+
 ```js
 import {fileTypeFromFile} from 'file-type';
 import {detectXml} from '@file-type/xml';


### PR DESCRIPTION
Changes:

- Allow file-type options to be directly passed to exported functions
- Improve coverage of type tests
- Centralized file-type options documentation (I want to introduce a new shared option in #646)

Related to #735, as this addresses some of the inconsistencies as well