### PR TITLE
Correct Matroska (video) MIME-type to formal IANA registration

### DIFF
--- a/core.js
+++ b/core.js
@@ -846,7 +846,7 @@ export class FileTypeParser {
 				case 'matroska':
 					return {
 						ext: 'mkv',
-						mime: 'video/x-matroska',
+						mime: 'video/matroska',
 					};
 
 				default:


### PR DESCRIPTION
Correct `video/x-matroska` to `video/matroska`, in line with IANA Registration: https://www.iana.org/assignments/media-types/video/matroska