### PR TITLE
Correct Apache Arrow MIME-type to formal IANA registration

### DIFF
--- a/core.js
+++ b/core.js
@@ -1199,7 +1199,7 @@ export class FileTypeParser {
 		if (this.check([0x41, 0x52, 0x52, 0x4F, 0x57, 0x31, 0x00, 0x00])) {
 			return {
 				ext: 'arrow',
-				mime: 'application/x-apache-arrow',
+				mime: 'application/vnd.apache.arrow.file',
 			};
 		}
 


### PR DESCRIPTION
Correct `application/x-apache-arrow` to  `application/vnd.apache.arrow.file` , in line with IANA registration: https://www.iana.org/assignments/media-types/application/vnd.apache.arrow.file