### PR TITLE
Correct FLAC MIME-type to formal IANA registration

### DIFF
--- a/core.js
+++ b/core.js
@@ -709,7 +709,7 @@ export class FileTypeParser {
 		if (this.checkString('fLaC')) {
 			return {
 				ext: 'flac',
-				mime: 'audio/x-flac',
+				mime: 'audio/flac',
 			};
 		}
 

--- a/supported.js
+++ b/supported.js
@@ -228,7 +228,7 @@ export const mimeTypes = [
 	'audio/ogg',
 	'audio/ogg; codecs=opus',
 	'application/ogg',
-	'audio/x-flac',
+	'audio/flac',
 	'audio/ape',
 	'audio/wavpack',
 	'audio/amr',


### PR DESCRIPTION
Correct `audio/x-flac` to `audio/flac`, in line with IANA Registration: https://www.iana.org/assignments/media-types/audio/flac

Updated supported.js, including corrections corresponding to #753, #754
