### PR TITLE
Exclude unknown file types from MIME/extension sync test

### DIFF
--- a/test.js
+++ b/test.js
@@ -723,9 +723,11 @@ test('implemented MIME types and extensions match the list of supported ones', a
 	const implementedExtensions = new Set();
 
 	for (const {path} of getFixtures()) {
-		const {mime, ext} = await fileTypeFromFile(path) ?? {};
-		implementedMimeTypes.add(mime);
-		implementedExtensions.add(ext);
+		const fileType = await fileTypeFromFile(path);
+		if (fileType) {
+			implementedMimeTypes.add(fileType.mime);
+			implementedExtensions.add(fileType.ext);
+		}
 	}
 
 	const differencesInMimeTypes = symmetricDifference(supportedMimeTypes, implementedMimeTypes);


### PR DESCRIPTION
Exclude unknown (`undefined`) file types from unit test "implemented MIME types and extensions match the list of supported ones"

This improves / fixes change from #756.
