### PR TITLE
Add UTF-16 (BE and LE) string compare

### DIFF
--- a/test.js
+++ b/test.js
@@ -958,6 +958,10 @@ test('should detect MPEG frame which is out of sync with the mpegOffsetTolerance
 	t.deepEqual(result, {ext: 'mp3', mime: 'audio/mpeg'}, 'detect an MP3 which 1 byte out of sync');
 });
 
+function loopEncoding(t, stringValue, encoding) {
+	t.deepEqual(new TextDecoder(encoding).decode(new Uint8Array(stringToBytes(stringValue, encoding))), stringValue, `Ensure consistency with TextDecoder with encoding ${encoding}`);
+}
+
 test('stringToBytes encodes correctly for selected characters and encodings', t => {
 	// Default encoding: basic ASCII
 	t.deepEqual(
@@ -993,4 +997,9 @@ test('stringToBytes encodes correctly for selected characters and encodings', t 
 		[0xD8, 0x3E, 0xDD, 0x84],
 		'should encode 🦄 (U+1F984) correctly in utf-16be',
 	);
+
+	loopEncoding(t, '🦄', 'utf-16le');
+	loopEncoding(t, '🦄', 'utf-16be');
+
+	t.is(new TextDecoder('utf-16be').decode(new Uint8Array(stringToBytes('🦄', 'utf-16be'))), '🦄', 'Decoded value should match original value');
 });

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ import {Parser as ReadmeParser} from 'commonmark';
 import * as strtok3 from 'strtok3/core';
 import {areUint8ArraysEqual} from 'uint8array-extras';
 import {getStreamAsArrayBuffer} from 'get-stream';
-import {stringToBytes} from './util.js'; // Adjust path as needed
+import {stringToBytes} from './util.js';
 import {
 	fileTypeFromBuffer,
 	fileTypeFromStream as fileTypeNodeFromStream,

--- a/test.js
+++ b/test.js
@@ -10,6 +10,7 @@ import {Parser as ReadmeParser} from 'commonmark';
 import * as strtok3 from 'strtok3/core';
 import {areUint8ArraysEqual} from 'uint8array-extras';
 import {getStreamAsArrayBuffer} from 'get-stream';
+import {stringToBytes} from './util.js'; // Adjust path as needed
 import {
 	fileTypeFromBuffer,
 	fileTypeFromStream as fileTypeNodeFromStream,
@@ -955,4 +956,41 @@ test('should detect MPEG frame which is out of sync with the mpegOffsetTolerance
 
 	result = await fileTypeFromFile(badOffset10Path, {mpegOffsetTolerance: 10});
 	t.deepEqual(result, {ext: 'mp3', mime: 'audio/mpeg'}, 'detect an MP3 which 1 byte out of sync');
+});
+
+test('stringToBytes encodes correctly for selected characters and encodings', t => {
+	// Default encoding: basic ASCII
+	t.deepEqual(
+		stringToBytes('ABC'),
+		[65, 66, 67],
+		'should encode ASCII correctly using default encoding',
+	);
+
+	// UTF-16LE with character above 0xFF
+	t.deepEqual(
+		stringToBytes('ꟻ', 'utf-16le'),
+		[0xFB, 0xA7],
+		'should encode U+A7FB correctly in utf-16le',
+	);
+
+	// UTF-16BE with character above 0xFF
+	t.deepEqual(
+		stringToBytes('ꟻ', 'utf-16be'),
+		[0xA7, 0xFB],
+		'should encode U+A7FB correctly in utf-16be',
+	);
+
+	// UTF-16LE with surrogate pair (🦄)
+	t.deepEqual(
+		stringToBytes('🦄', 'utf-16le'),
+		[0x3E, 0xD8, 0x84, 0xDD],
+		'should encode 🦄 (U+1F984) correctly in utf-16le',
+	);
+
+	// UTF-16BE with surrogate pair (🦄)
+	t.deepEqual(
+		stringToBytes('🦄', 'utf-16be'),
+		[0xD8, 0x3E, 0xDD, 0x84],
+		'should encode 🦄 (U+1F984) correctly in utf-16be',
+	);
 });

--- a/util.js
+++ b/util.js
@@ -3,8 +3,8 @@ import {StringType} from 'token-types';
 export function stringToBytes(string, encoding) {
 	if (encoding === 'utf-16le') {
 		const bytes = [];
-		for (let i = 0; i < string.length; i++) {
-			const code = string.charCodeAt(i); // eslint-disable-line unicorn/prefer-code-point
+		for (let index = 0; index < string.length; index++) {
+			const code = string.charCodeAt(index); // eslint-disable-line unicorn/prefer-code-point
 			bytes.push(code & 0xFF, (code >> 8) & 0xFF); // High byte
 		}
 
@@ -13,8 +13,8 @@ export function stringToBytes(string, encoding) {
 
 	if (encoding === 'utf-16be') {
 		const bytes = [];
-		for (let i = 0; i < string.length; i++) {
-			const code = string.charCodeAt(i); // eslint-disable-line unicorn/prefer-code-point
+		for (let index = 0; index < string.length; index++) {
+			const code = string.charCodeAt(index); // eslint-disable-line unicorn/prefer-code-point
 			bytes.push((code >> 8) & 0xFF, code & 0xFF); // Low byte
 		}
 

--- a/util.js
+++ b/util.js
@@ -1,6 +1,26 @@
 import {StringType} from 'token-types';
 
-export function stringToBytes(string) {
+export function stringToBytes(string, encoding) {
+	if (encoding === 'utf-16le') {
+		const bytes = [];
+		for (let i = 0; i < string.length; i++) {
+			const code = string.charCodeAt(i); // eslint-disable-line unicorn/prefer-code-point
+			bytes.push(code & 0xFF, (code >> 8) & 0xFF); // High byte
+		}
+
+		return bytes;
+	}
+
+	if (encoding === 'utf-16be') {
+		const bytes = [];
+		for (let i = 0; i < string.length; i++) {
+			const code = string.charCodeAt(i); // eslint-disable-line unicorn/prefer-code-point
+			bytes.push((code >> 8) & 0xFF, code & 0xFF); // Low byte
+		}
+
+		return bytes;
+	}
+
 	return [...string].map(character => character.charCodeAt(0)); // eslint-disable-line unicorn/prefer-code-point
 }
 


### PR DESCRIPTION
Add internal support to compare UTF16-BE and UTF16-LE strings.

Reason I added this, is because I want to follow up with support Windows registry change files, which are prefixed with `Windows Registry Editor Version 5.00`,  in a UTF16-LE encoded, BOM prefixed text file.

Keeps the code more compact and readable, if we use the actual strings we are comparing.
