### PR TITLE
Normalize MIME-types we invented with `/x-ft-` prefix

### DIFF
--- a/core.js
+++ b/core.js
@@ -723,7 +723,7 @@ export class FileTypeParser {
 		if (this.checkString('LZIP')) {
 			return {
 				ext: 'lz',
-				mime: 'application/x-lzip',
+				mime: 'application/lzip',
 			};
 		}
 
@@ -943,7 +943,7 @@ export class FileTypeParser {
 		if (this.check([0x04, 0x22, 0x4D, 0x18])) {
 			return {
 				ext: 'lz4',
-				mime: 'application/x-lz4', // Invented by us
+				mime: 'application/x-lz4',
 			};
 		}
 
@@ -1056,7 +1056,7 @@ export class FileTypeParser {
 		if (this.checkString('DRACO')) {
 			return {
 				ext: 'drc',
-				mime: 'application/vnd.google.draco', // Invented by us
+				mime: 'application/x-ft-draco',
 			};
 		}
 
@@ -1616,21 +1616,21 @@ export class FileTypeParser {
 		if (this.check([0x4C, 0x00, 0x00, 0x00, 0x01, 0x14, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46])) {
 			return {
 				ext: 'lnk',
-				mime: 'application/x.ms.shortcut', // Invented by us
+				mime: 'application/x-ms-shortcut', // Informal, used by freedesktop.org. shared-mime-info
 			};
 		}
 
 		if (this.check([0x62, 0x6F, 0x6F, 0x6B, 0x00, 0x00, 0x00, 0x00, 0x6D, 0x61, 0x72, 0x6B, 0x00, 0x00, 0x00, 0x00])) {
 			return {
 				ext: 'alias',
-				mime: 'application/x.apple.alias', // Invented by us
+				mime: 'application/x-ft-apple.alias',
 			};
 		}
 
 		if (this.checkString('Kaydara FBX Binary  \u0000')) {
 			return {
 				ext: 'fbx',
-				mime: 'application/x.autodesk.fbx', // Invented by us
+				mime: 'application/x-ft-fbx',
 			};
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -122,8 +122,7 @@ Returns a `Promise` for an object with the detected file type:
 - `ext` - One of the [supported file types](#supported-file-types)
 - `mime` - The [MIME type](https://en.wikipedia.org/wiki/Internet_media_type)
 
-MIME media subtypes prefixed with `x-ft-` are custom and defined by us.
-They are neither formally registered with IANA nor based on any informal conventions.
+MIME media subtypes prefixed with `x-ft-` are custom and defined by us. They are neither formally registered with IANA nor based on any informal conventions.
 
 Or `undefined` when there is no match.
 

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,9 @@ Returns a `Promise` for an object with the detected file type:
 - `ext` - One of the [supported file types](#supported-file-types)
 - `mime` - The [MIME type](https://en.wikipedia.org/wiki/Internet_media_type)
 
+MIME media subtypes prefixed with `x-ft-` are custom and defined by us.
+They are neither formally registered with IANA nor based on any informal conventions.
+
 Or `undefined` when there is no match.
 
 #### buffer

--- a/supported.js
+++ b/supported.js
@@ -179,6 +179,10 @@ export const extensions = [
 	'dat',
 ];
 
+/**
+MIME media subtypes prefixed with `x-ft-` are custom and defined by us.
+They are neither formally registered with IANA nor based on any informal conventions.
+ */
 export const mimeTypes = [
 	'image/jpeg',
 	'image/png',
@@ -260,7 +264,7 @@ export const mimeTypes = [
 	'application/x-unix-archive',
 	'application/x-rpm',
 	'application/x-compress',
-	'application/x-lzip',
+	'application/lzip',
 	'application/x-cfb',
 	'application/x-mie',
 	'application/mxf',
@@ -288,9 +292,9 @@ export const mimeTypes = [
 	'text/vtt',
 	'model/gltf-binary',
 	'application/vnd.tcpdump.pcap',
-	'audio/x-dsf', // Non-standard
-	'application/x.ms.shortcut', // Invented by us
-	'application/x.apple.alias', // Invented by us
+	'audio/x-dsf', // Informal
+	'application/x-ms-shortcut', // Informal, used by freedesktop.org. shared-mime-info
+	'application/x-ft-apple.alias',
 	'audio/x-voc',
 	'audio/vnd.dolby.dd-raw',
 	'audio/x-m4a',
@@ -330,10 +334,10 @@ export const mimeTypes = [
 	'application/x-ace-compressed',
 	'application/avro',
 	'application/vnd.iccprofile',
-	'application/x.autodesk.fbx', // Invented by us
+	'application/x-ft-fbx',
 	'application/vnd.visio',
 	'application/vnd.android.package-archive',
-	'application/vnd.google.draco', // Invented by us
+	'application/x-ft-draco',
 	'application/x-lz4', // Invented by us
 	'application/vnd.openxmlformats-officedocument.presentationml.template',
 	'application/vnd.openxmlformats-officedocument.spreadsheetml.template',

--- a/supported.js
+++ b/supported.js
@@ -180,9 +180,8 @@ export const extensions = [
 ];
 
 /**
-MIME media subtypes prefixed with `x-ft-` are custom and defined by us.
-They are neither formally registered with IANA nor based on any informal conventions.
- */
+MIME media subtypes prefixed with `x-ft-` are custom and defined by us. They are neither formally registered with IANA nor based on any informal conventions.
+*/
 export const mimeTypes = [
 	'image/jpeg',
 	'image/png',


### PR DESCRIPTION
MIME media subtypes prefixed with `x-ft-` are custom-defined by us.
They are neither formally registered with IANA nor based on any informal conventions.

These MIME-type mappings changed:
- `application/x-lzip` ↦ `application/lzip` (based on https://datatracker.ietf.org/doc/draft-diaz-lzip/)
- `application/x.ms.shortcut` ↦ `application/x-ms-shortcut`
- `application/x.apple.alias` ↦ `application/x-ft-apple.alias`
- `application/x.autodesk.fbx` ↦ `application/x-ft-fbx`
- `application/vnd.google.draco` ↦ `application/x-ft-draco`

