### PR TITLE
Use `strtok3.parseBlob` for improved Blob handling

### DIFF
--- a/core.js
+++ b/core.js
@@ -234,7 +234,12 @@ export class FileTypeParser {
 	}
 
 	async fromBlob(blob) {
-		return this.fromStream(blob.stream());
+		const tokenizer = strtok3.fromBlob(blob, this.tokenizerOptions);
+		try {
+			return await this.fromTokenizer(tokenizer);
+		} finally {
+			await tokenizer.close();
+		}
 	}
 
 	async fromStream(stream) {


### PR DESCRIPTION
Replaced the existing [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) parsing logic with [`strtok3.parseBlob`](https://github.com/Borewit/strtok3?tab=readme-ov-file#fromblob-function), which internally uses `Blob.slice`.
This approach is advantageous when working with Blobs that support random access.

For example, [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options) returns a Blob that allows efficient slicing, making strtok3.parseBlob a better fit for performance and flexibility.

