### PR TITLE
Document `@file-type/av` third-party file-type detectors

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -394,6 +394,7 @@ console.log(fileType);
 
 ### Available third-party file-type detectors
 
+- [@file-type/av](https://github.com/Borewit/file-type-av): Enhances audio / video type detection, able to distinct between audio and video media files
 - [@file-type/xml](https://github.com/Borewit/file-type-xml): Detects common XML file types, such as GLM, KML, MusicXML, RSS, SVG, and XHTML
 
 ### Detector execution flow


### PR DESCRIPTION
Document third-party file-type detector: [@file-type/av](https://github.com/Borewit/file-type-av).

This detector enhances audio / video media file type detection, able to distinct between audio and video media files, utilizing [music-metadata](https://github.com/Borewit/music-metadata).
