### PR TITLE
Handle partial unzip

### DIFF
--- a/core.js
+++ b/core.js
@@ -597,7 +597,7 @@ export class FileTypeParser {
 
 						return {};
 				}
-			});
+			}).catch(() => {});
 
 			return fileType ?? {
 				ext: 'zip',


### PR DESCRIPTION
Do not throw the `EndOfStreamError()` exception in case you pass only partial zip data.

Code to reproduce the error:
```
file.stream.once('data', async (firstChunk) => {
    const type = await fileTypeFromBuffer(firstChunk)
})
```

Stack trace:
```
EndOfStreamError: End-Of-Stream
at BufferTokenizer.peekBuffer (file:///opt/novatalks.engine/node_modules/strtok3/lib/BufferTokenizer.js:38:19)
at BufferTokenizer.readBuffer (file:///opt/novatalks.engine/node_modules/strtok3/lib/BufferTokenizer.js:24:38)
at BufferTokenizer.readToken (file:///opt/novatalks.engine/node_modules/strtok3/lib/AbstractTokenizer.js:32:32)
at ZipHandler.unzip (file:///opt/novatalks.engine/node_modules/@tokenizer/inflate/lib/index.js:127:61)
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
at async Object.detectConfident [as detect] (file:///opt/novatalks.engine/node_modules/file-type/core.js:521:4)
at async FileTypeParser.fromTokenizer (file:///opt/novatalks.engine/node_modules/file-type/core.js:211:21)
```