### PR TITLE
Handle zip errors so we can still tell the file is a zip.

### DIFF
--- a/core.js
+++ b/core.js
@@ -601,7 +601,6 @@ export class FileTypeParser {
 					}
 				});
 			} catch {}
-		
 
 			return fileType ?? {
 				ext: 'zip',


### PR DESCRIPTION
In the web environment, fileTypeFromStream often gives End-Of-Stream errors with ZIP files. Even if the ZIP parser fails, we should still return that the file is a ZIP.