### PR TITLE
List `@file-type/pdf` in available plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -395,6 +395,7 @@ console.log(fileType);
 ### Available third-party file-type detectors
 
 - [@file-type/av](https://github.com/Borewit/file-type-av): Improves detection of audio and video file formats, with accurate differentiation between the two
+- [@file-type/pdf](https://github.com/Borewit/file-type-pdf): Detects PDF based file types, such as Adobe Illustrator
 - [@file-type/xml](https://github.com/Borewit/file-type-xml): Detects common XML file types, such as GLM, KML, MusicXML, RSS, SVG, and XHTML
 
 ### Detector execution flow


### PR DESCRIPTION
Document specialized PDF detector  [@file-type/pdf](https://github.com/Borewit/file-type-pdf).

The plugin also supports Adobe Illustrator (`.ai`) types.

Related changes & issues:
- https://github.com/sindresorhus/file-type/pull/743
- https://github.com/sindresorhus/file-type/issues/742
- https://github.com/sindresorhus/file-type/issues/582
- https://github.com/sindresorhus/file-type/issues/360
- https://github.com/sindresorhus/file-type/pull/323
- https://github.com/sindresorhus/file-type/issues/64
