### PR TITLE
Fix infinite loop in ASF parser on malformed input (v16 backport)

### DIFF
--- a/core.js
+++ b/core.js
@@ -1081,6 +1081,7 @@ async function _fromTokenizer(tokenizer) {
 		await tokenizer.ignore(30);
 		// Search for header should be in first 1KB of file.
 		while (tokenizer.position + 24 < tokenizer.fileInfo.size) {
+			const previousPosition = tokenizer.position;
 			const header = await readHeader();
 			let payload = header.size - 24;
 			if (_check(header.id, [0x91, 0x07, 0xDC, 0xB7, 0xB7, 0xA9, 0xCF, 0x11, 0x8E, 0xE6, 0x00, 0xC0, 0x0C, 0x20, 0x53, 0x65])) {
@@ -1108,6 +1109,11 @@ async function _fromTokenizer(tokenizer) {
 			}
 
 			await tokenizer.ignore(payload);
+
+			// Safeguard against malformed files: break if the position did not advance.
+			if (tokenizer.position <= previousPosition) {
+				break;
+			}
 		}
 
 		// Default to ASF generic extension

--- a/test.js
+++ b/test.js
@@ -548,3 +548,13 @@ test('corrupt MKV throws', async t => {
 	const filePath = path.join(__dirname, 'fixture/fixture-corrupt.mkv');
 	await t.throwsAsync(FileType.fromFile(filePath), {message: /out of range/});
 });
+
+test('Does not hang on crafted ASF file with zero-size sub-header', async t => {
+	const buffer = Buffer.from('3026b2758e66cf11a6d9000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', 'hex');
+	const type = await FileType.fromBuffer(buffer);
+
+	t.deepEqual(type, {
+		ext: 'asf',
+		mime: 'application/vnd.ms-asf'
+	});
+});


### PR DESCRIPTION
This PR backports https://github.com/sindresorhus/file-type/commit/319abf871b50ba2fa221b4a7050059f1ae096f4f to the `16` branch.